### PR TITLE
[BackEnd] Added Books Search Filter Option

### DIFF
--- a/backend/books/search_filters.py
+++ b/backend/books/search_filters.py
@@ -1,0 +1,14 @@
+from rest_framework import filters
+
+class CustomSearchFilter(filters.SearchFilter):
+    def get_search_fields(self, view, request):
+        if request.query_params.get('title_only'):
+            return ['title']
+        elif request.query_params.get('author_only'):
+            return ['authors__name']
+        elif request.query_params.get('publisher_only'):
+            return ['publisher']
+        elif request.query_params.get('isbn_only'):
+            return ['isbn_10', 'isbn_13']
+
+        return super().get_search_fields(view, request)

--- a/backend/books/views.py
+++ b/backend/books/views.py
@@ -12,6 +12,7 @@ from .serializers import BookAddSerializer, BookSerializer, ISBNSerializer
 from .isbn import ISBNTools
 from .models import Book, Author
 from .paginations import BookPagination
+from .search_filters import CustomSearchFilter
 
 from genres.models import Genre
 
@@ -75,7 +76,7 @@ class ListCreateBookAPIView(ListCreateAPIView):
     serializer_class = BookAddSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = BookPagination
-    filter_backends = [filters.OrderingFilter, filters.SearchFilter]
+    filter_backends = [filters.OrderingFilter, CustomSearchFilter]
     ordering_fields = '__all__'
     ordering = ['id']
     search_fields = ['authors__name', 'title', '=publisher', '=isbn_10', '=isbn_13']


### PR DESCRIPTION
## Feature Description (what did you do?)
- Book List, added "author_only", "title_only", "publisher_only", "isbn_only" query parameters for searching through a field - /api/v1/books/?search={search_value}&publisher_only={true} (Closes #90)

## Design/Implementation Details (how did you do it?)
- Created CustomSearchFilter - search_filters.py

## Areas Affected (what parts of the code does this affect?)
- Frontend API Endpoint for Book Searching

## Testing (how did you ensure this works correctly?)
- Postman Books-API section

## Future Considerations (is there anything we should know about this going forward?)
