### PR TITLE
[FrontEnd] Switch Endpoint to Localhost

### DIFF
--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,3 +1,3 @@
-REACT_APP_API_ENDPOINT_TOKEN=http://books-dev.colab.duke.edu:8000/api/v1/auth/users/login/
+REACT_APP_API_ENDPOINT_TOKEN=http://localhost:8000/api/v1/auth/users/login/
 
-REACT_APP_BACKEND_ENDPOINT=http://books-dev.colab.duke.edu:8000/api/v1/
+REACT_APP_BACKEND_ENDPOINT=http://localhost:8000/api/v1/

--- a/frontend/src/apis/Config.tsx
+++ b/frontend/src/apis/Config.tsx
@@ -2,7 +2,7 @@ import axios, { AxiosError } from "axios";
 import { stringify } from "qs";
 import { logger } from "../util/Logger";
 
-export const BACKEND_ENDPOINT = "http://books-dev.colab.duke.edu:8000/api/v1/";
+export const BACKEND_ENDPOINT = process.env.REACT_APP_BACKEND_ENDPOINT;
 export const JSON_HEADER = { "Content-Type": "application/json" };
 export const METHOD_POST = "POST";
 export const METHOD_GET = "GET";


### PR DESCRIPTION
## Feature Description (what did you do?)

Needed to switch the front end endpoint to hit localhost rather than books-dev, because we want to do this when our frontend/backend are running on the same server

## Design/Implementation Details (how did you do it?)

## Areas Affected (what parts of the code does this affect?)

## Testing (how did you ensure this works correctly?)

## Future Considerations (is there anything we should know about this going forward?)
