### PR TITLE
Enable ability to list all pieces of data

### DIFF
--- a/backend/books/views.py
+++ b/backend/books/views.py
@@ -81,6 +81,12 @@ class ListCreateBookAPIView(ListCreateAPIView):
     ordering = ['id']
     search_fields = ['authors__name', 'title', '=publisher', '=isbn_10', '=isbn_13']
 
+    def paginate_queryset(self, queryset):
+        if 'no_pagination' in self.request.query_params:
+            return None
+        else:
+            return super().paginate_queryset(queryset)
+
     # Override default create method
     def create(self, request, *args, **kwargs):
         # Need to handle creating authors and genres if not present in DB

--- a/backend/genres/views.py
+++ b/backend/genres/views.py
@@ -20,6 +20,12 @@ class ListCreateGenreAPIView(ListCreateAPIView):
     ordering_fields = '__all__'
     ordering = ['id']
 
+    def paginate_queryset(self, queryset):
+        if 'no_pagination' in self.request.query_params:
+            return None
+        else:
+            return super().paginate_queryset(queryset)
+
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
 

--- a/backend/purchase_orders/views.py
+++ b/backend/purchase_orders/views.py
@@ -19,6 +19,12 @@ class ListCreatePurchaseOrderAPIView(ListCreateAPIView):
     ordering_fields = '__all__'
     ordering = ['id']
 
+    def paginate_queryset(self, queryset):
+        if 'no_pagination' in self.request.query_params:
+            return None
+        else:
+            return super().paginate_queryset(queryset)
+
     def create(self, request, *args, **kwargs):
         serializer = PurchaseOrderSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/sales/views.py
+++ b/backend/sales/views.py
@@ -19,6 +19,12 @@ class ListCreateSalesReconciliationAPIView(ListCreateAPIView):
     ordering_fields = '__all__'
     ordering = ['id']
 
+    def paginate_queryset(self, queryset):
+        if 'no_pagination' in self.request.query_params:
+            return None
+        else:
+            return super().paginate_queryset(queryset)
+
     def create(self, request, *args, **kwargs):
         serializer = SalesReconciliationSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/backend/vendors/views.py
+++ b/backend/vendors/views.py
@@ -18,6 +18,12 @@ class ListCreateVendorAPIView(ListCreateAPIView):
     ordering_fields = '__all__'
     ordering = ['name']
 
+    def paginate_queryset(self, queryset):
+        if 'no_pagination' in self.request.query_params:
+            return None
+        else:
+            return super().paginate_queryset(queryset)
+
 class RetrieveUpdateDestroyVendorAPIView(RetrieveUpdateDestroyAPIView):
     serializer_class = VendorSerializer
     queryset = Vendor.objects.all()


### PR DESCRIPTION
## Feature Description (what did you do?)
Implemented ability to list all of the data if requested for sales reconciliations, purchase orders, vendors, books, and genres
## Design/Implementation Details (how did you do it?)
I overrode the `paginate_queryset` method in each of their ListCreate classes.
## Areas Affected (what parts of the code does this affect?)
Frontend can call this API with query param as just `no_pagination` (i.e. not equal value needed)
## Testing (how did you ensure this works correctly?)
Postman and localhost
## Future Considerations (is there anything we should know about this going forward?)
