### PR TITLE
Change format faulty isbns

### DIFF
--- a/backend/books/isbn.py
+++ b/backend/books/isbn.py
@@ -1,6 +1,5 @@
 from urllib.request import urlopen
 import json
-from pprint import pprint
 from isbnlib import *
 from dateutil import parser
 

--- a/backend/books/isbn.py
+++ b/backend/books/isbn.py
@@ -105,4 +105,4 @@ class ISBNTools:
             list: The parsed ISBN list formatted to ISBN13.
 
         """
-        return [self.parse_isbn(raw_isbn) for raw_isbn in isbn_list]
+        return [self.parse_isbn(raw_isbn) if raw_isbn.isdigit() else raw_isbn for raw_isbn in isbn_list]


### PR DESCRIPTION
## Feature Description (what did you do?)
Changed format of data returned from the POST request to retrieve book initial data. Also ensured that isbns that are requested that don't follow the isbn correct format will also be returned as an invalid isbn, instead of dissapearing.
## Design/Implementation Details (how did you do it?)
Change it to be a dictionary mapping "books" to a list of valid book data retrieved, and then "invalid_isbns" mapped to a list of the invalid isbns.
## Areas Affected (what parts of the code does this affect?)
Invalid ISBNS will not be returned as separate list from the valid book data.
## Testing (how did you ensure this works correctly?)
Postman and localhost running
## Future Considerations (is there anything we should know about this going forward?)
