### PR TITLE
[BugFix] Bugfix devops https security

### DIFF
--- a/backend/hypothetical_books_backend/settings.py
+++ b/backend/hypothetical_books_backend/settings.py
@@ -30,7 +30,7 @@ SECRET_KEY = env('SECRET_KEY')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env('DEBUG').lower() == 'true'
 
-ALLOWED_HOSTS = ['books.colab.duke.edu']
+ALLOWED_HOSTS = ['books.colab.duke.edu', 'books-dev.colab.duke.edu']
 # ALLOWED_HOSTS = ['*']
 
 # Application definition

--- a/backend/hypothetical_books_backend/settings.py
+++ b/backend/hypothetical_books_backend/settings.py
@@ -28,10 +28,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = env('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = env('DEBUG')
+DEBUG = env('DEBUG').lower() == 'true'
 
-# ALLOWED_HOSTS = ['books.colab.duke.edu']
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ['books.colab.duke.edu']
+# ALLOWED_HOSTS = ['*']
 
 # Application definition
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: frontend-image
     build: ./frontend
     ports: 
-      - 80:3000
+      - 3000:3000
     environment:
       env_file: ./frontend/.env.development
   frontend-hot-reload:
@@ -20,4 +20,4 @@ services:
     image: backend-image
     build: ./backend
     ports:
-      - "8000:8000"
+      - 8000:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,5 +19,5 @@ services:
   backend:
     image: backend-image
     build: ./backend
-    ports:
+    ports: 
       - 8000:8000


### PR DESCRIPTION
## Feature Description (what did you do?)
- Changed /api endpoint to head to backend django server with HTTPS enabled.
- Disallowed any incoming request in HTTP.

## Design/Implementation Details (how did you do it?)
- Mostly devops code so all the heavy lifting is done at devops repo [ECE-458-Books/devops](https://github.com/ECE-458-Books/devops)

## Areas Affected (what parts of the code does this affect?)
- All Backend API Point will change from http to https, also we will not be exposing our port number (8000)

## Testing (how did you ensure this works correctly?)
- Postman

## Future Considerations (is there anything we should know about this going forward?)
- UFW concern also addressed at #119 