### PR TITLE
[BugFix] Added Vendor Delete iff No PO Related & Changed Status Error to 409

### DIFF
--- a/backend/genres/views.py
+++ b/backend/genres/views.py
@@ -84,7 +84,7 @@ class RetrieveUpdateDestroyGenreAPIView(RetrieveUpdateDestroyAPIView):
         associated_book_cnt = len(instance.book_set.all())
         if(associated_book_cnt != 0):
             error_msg = {"error": f"{associated_book_cnt} book(s) associated with genre:{instance.name}"}
-            return Response(error_msg, status=status.HTTP_400_BAD_REQUEST)
+            return Response(error_msg, status=status.HTTP_409_CONFLICT)
 
         # Perform destroy of instance
         self.perform_destroy(instance)

--- a/backend/vendors/serializers.py
+++ b/backend/vendors/serializers.py
@@ -2,10 +2,15 @@ from rest_framework import serializers
 
 from .models import Vendor
 
+from purchase_orders.models import PurchaseOrder
+
 class VendorSerializer(serializers.ModelSerializer):
-    # Uncomment when purchase_order app is made
-    # purchase_orders = serializers.PrimaryKeyRelatedField(many=True, read_only=True)
+    num_purchase_orders = serializers.SerializerMethodField()
 
     class Meta:
         model = Vendor
         fields = '__all__'
+        # fields = ['id', 'name', 'num_purchase_orders']
+    
+    def get_num_purchase_orders(self, instance):
+        return len(PurchaseOrder.objects.filter(vendor=instance.id))

--- a/backend/vendors/serializers.py
+++ b/backend/vendors/serializers.py
@@ -5,12 +5,8 @@ from .models import Vendor
 from purchase_orders.models import PurchaseOrder
 
 class VendorSerializer(serializers.ModelSerializer):
-    num_purchase_orders = serializers.SerializerMethodField()
+    num_purchase_orders = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Vendor
-        fields = '__all__'
-        # fields = ['id', 'name', 'num_purchase_orders']
-    
-    def get_num_purchase_orders(self, instance):
-        return len(PurchaseOrder.objects.filter(vendor=instance.id))
+        fields = ['id', 'name', 'num_purchase_orders']

--- a/backend/vendors/views.py
+++ b/backend/vendors/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Count
+from django.db.models import Count, OuterRef, Subquery, Func
 
 from rest_framework import filters, status
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
@@ -25,6 +25,24 @@ class ListCreateVendorAPIView(ListCreateAPIView):
             return None
         else:
             return super().paginate_queryset(queryset)
+    
+    def get_queryset(self):
+        default_query_set = Vendor.objects.all()
+
+        default_query_set = default_query_set.annotate(
+            num_purchase_orders=Subquery(
+                PurchaseOrder.objects.filter(
+                    vendor=OuterRef('id')
+                ).values_list(
+                    Func(
+                        'id',
+                        function='COUNT',
+                    ),
+                )
+            )
+        )
+        
+        return default_query_set
 
 
 class RetrieveUpdateDestroyVendorAPIView(RetrieveUpdateDestroyAPIView):

--- a/backend/vendors/views.py
+++ b/backend/vendors/views.py
@@ -9,6 +9,8 @@ from .serializers import VendorSerializer
 from .models import Vendor
 from .paginations import VendorPagination
 
+from purchase_orders.models import PurchaseOrder
+
 class ListCreateVendorAPIView(ListCreateAPIView):
     serializer_class = VendorSerializer
     queryset = Vendor.objects.all()
@@ -31,14 +33,19 @@ class RetrieveUpdateDestroyVendorAPIView(RetrieveUpdateDestroyAPIView):
     lookup_url_kwarg = 'id'
 
     def destroy(self, request, *args, **kwargs):
-        instance = self.get_object()
-        
-        # Uncomment when purchase order is linked
+        # Check if the request url is valid
+        try:
+            instance = self.get_object()
+        except Exception as e:
+            return Response({"error": f"{e}"}, status=status.HTTP_204_NO_CONTENT)
+
         # Check to see if the Vendor has no purchase orders associated
-        # associated_purchase_order_cnt = len(instance.purchase_order_set.all())
-        # if(associated_purchase_order_cnt != 0):
-        #     error_msg = {"error": f"{associated_purchase_order_cnt} purchase order(s) associated with vendor:{instance.name}"}
-        #     return Response(error_msg, status=status.HTTP_400_BAD_REQUEST)
+        queryset = PurchaseOrder.objects.filter(vendor_id=instance.id)
+
+        associated_purchase_order_cnt = len(queryset)
+        if(associated_purchase_order_cnt != 0):
+            error_msg = {"error": f"{associated_purchase_order_cnt} purchase order(s) associated with vendor:{instance.name}"}
+            return Response(error_msg, status=status.HTTP_409_CONFLICT)
 
         self.perform_destroy(instance)
         return Response({"destroy": "success"}, status=status.HTTP_204_NO_CONTENT)

--- a/backend/vendors/views.py
+++ b/backend/vendors/views.py
@@ -26,6 +26,7 @@ class ListCreateVendorAPIView(ListCreateAPIView):
         else:
             return super().paginate_queryset(queryset)
 
+
 class RetrieveUpdateDestroyVendorAPIView(RetrieveUpdateDestroyAPIView):
     serializer_class = VendorSerializer
     queryset = Vendor.objects.all()


### PR DESCRIPTION
## Feature Description (what did you do?)
- Added Vendor Delete if and only if No PO Related to that Vendor - (Closes #133)

## Design/Implementation Details (how did you do it?)
- Override the destroy function at RetrieveUpdateDestroyVendorAPIView - views.py
- Changed the status code to 400 (BAD_REQUEST) to 409 (CONFLICT)
- Check the PurchaseOrder objects and see if there are any vendors related (ManyToOne)

## Areas Affected (what parts of the code does this affect?)
- Frontend API Endpoint

## Testing (how did you ensure this works correctly?)
- Postman

## Future Considerations (is there anything we should know about this going forward?)
