### PR TITLE
[BugFix] Disallow Sales Reconciliation to have no Sales

### DIFF
--- a/backend/sales/serializers.py
+++ b/backend/sales/serializers.py
@@ -58,7 +58,10 @@ class SalesReconciliationSerializer(serializers.ModelSerializer):
         # Sanity check if there exists at least one sale in SR
         if(len(sales_data) < 1):
             raise APIException({
-                "error": "There must be at least one sales in sales reconciliation."
+                "error": {
+                    "query": "SR CREATE",
+                    "msg" : "There must be at least one sales in sales reconciliation."
+                }
             })
 
         sales_reconciliation = SalesReconciliation.objects.create(**validated_data)
@@ -72,6 +75,16 @@ class SalesReconciliationSerializer(serializers.ModelSerializer):
 
         existing_sales = Sale.objects.filter(sales_reconciliation_id=instance.id)
         existing_sales_ids = set([sale.id for sale in existing_sales])
+
+        # Sanity check if there exists at least one sale in SR
+        if(len(sales_update_data) < 1):
+            raise APIException({
+                "error": {
+                    "query": "SR UPDATE",
+                    "msg" : "There must be at least one sales in sales reconciliation."
+                }
+            })
+
         for sale_data in sales_update_data:
             sale_id = sale_data.get('id', None)
             if sale_id:  # Sale already exists

--- a/backend/sales/serializers.py
+++ b/backend/sales/serializers.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
-from books.models import Book
+from rest_framework.exceptions import APIException
+
 from .models import Sale, SalesReconciliation
+
+from books.models import Book
 from purchase_orders.models import Purchase, PurchaseOrder
 
 
@@ -51,6 +54,13 @@ class SalesReconciliationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         sales_data = validated_data.pop('sales')
+
+        # Sanity check if there exists at least one sale in SR
+        if(len(sales_data) < 1):
+            raise APIException({
+                "error": "There must be at least one sales in sales reconciliation."
+            })
+
         sales_reconciliation = SalesReconciliation.objects.create(**validated_data)
         for sale_data in sales_data:
             Sale.objects.create(sales_reconciliation=sales_reconciliation, **sale_data)


### PR DESCRIPTION
## Feature Description (what did you do?)
- Disallow Sales Reconciliation to have no Sales

## Design/Implementation Details (how did you do it?)
- Added APIExceptions when creating, updating SRs - serializers.py

## Areas Affected (what parts of the code does this affect?)

## Testing (how did you ensure this works correctly?)
- Postman

## Future Considerations (is there anything we should know about this going forward?)
