### PR TITLE
[Front-End] Multiple Genre & Vendor Add simultaneously

### DIFF
--- a/frontend/src/pages/add/BookAdd.tsx
+++ b/frontend/src/pages/add/BookAdd.tsx
@@ -282,6 +282,7 @@ export default function BookAdd() {
             <InputTextarea
               id="addbook"
               name="addbook"
+              placeholder="Add Multiple Books using commas"
               value={textBox}
               onChange={(e: FormEvent<HTMLTextAreaElement>) =>
                 setTextBox(e.currentTarget.value)

--- a/frontend/src/pages/add/GenreAdd.tsx
+++ b/frontend/src/pages/add/GenreAdd.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useRef, useState } from "react";
+import React, { FormEvent, useEffect, useRef, useState } from "react";
 import { InputTextarea } from "primereact/inputtextarea";
 import { Button } from "primereact/button";
 import { GENRES_API } from "../../apis/GenresAPI";
@@ -24,13 +24,11 @@ export default function GenreAdd() {
 
   const onSubmit = (event: FormEvent<HTMLFormElement>): void => {
     logger.debug("Add Genre Submitted", textBox);
-    GENRES_API.addGenres(textBox).then((response) => {
-      if (response.status == 201) {
-        showSuccess();
-      } else {
-        showFailure();
-      }
-    });
+    let str: string[] = textBox.split(/\r?\n/);
+    str = str.filter((str) => /\S/.test(str));
+    for (let i = 0; i < str.length; i++) {
+      GENRES_API.addGenres(str[i]);
+    }
     event.preventDefault();
   };
 

--- a/frontend/src/pages/add/GenreAdd.tsx
+++ b/frontend/src/pages/add/GenreAdd.tsx
@@ -27,7 +27,11 @@ export default function GenreAdd() {
     let str: string[] = textBox.split(/\r?\n/);
     str = str.filter((str) => /\S/.test(str));
     for (let i = 0; i < str.length; i++) {
-      GENRES_API.addGenres(str[i]);
+      GENRES_API.addGenres(str[i]).then((response) => {
+        if (response.status == 201) {
+          showSuccess();
+        }
+      });
     }
     event.preventDefault();
   };
@@ -57,6 +61,7 @@ export default function GenreAdd() {
           <InputTextarea
             id="addgenre"
             name="addgenre"
+            placeholder="Enter Multiple Genres using Newline breaks"
             value={textBox}
             onChange={(e: FormEvent<HTMLTextAreaElement>) =>
               setTextBox(e.currentTarget.value)

--- a/frontend/src/pages/add/GenreAdd.tsx
+++ b/frontend/src/pages/add/GenreAdd.tsx
@@ -1,4 +1,4 @@
-import React, { FormEvent, useEffect, useRef, useState } from "react";
+import React, { FormEvent, useRef, useState } from "react";
 import { InputTextarea } from "primereact/inputtextarea";
 import { Button } from "primereact/button";
 import { GENRES_API } from "../../apis/GenresAPI";
@@ -24,12 +24,19 @@ export default function GenreAdd() {
 
   const onSubmit = (event: FormEvent<HTMLFormElement>): void => {
     logger.debug("Add Genre Submitted", textBox);
+    //take string input assigned to variable textBox and parse it based on newline character
+    //into a string array using a regular expression
     let str: string[] = textBox.split(/\r?\n/);
+    //take the string array -> check for and remove any elements containing only whitespace
+    //or nothing at all
     str = str.filter((str) => /\S/.test(str));
+    //loop through all elements and do an API submission to add the strings to database
     for (let i = 0; i < str.length; i++) {
       GENRES_API.addGenres(str[i]).then((response) => {
         if (response.status == 201) {
           showSuccess();
+        } else {
+          showFailure();
         }
       });
     }

--- a/frontend/src/pages/add/VendorAdd.tsx
+++ b/frontend/src/pages/add/VendorAdd.tsx
@@ -24,13 +24,11 @@ export default function VendorAdd() {
 
   const onSubmit = (event: FormEvent<HTMLFormElement>): void => {
     logger.debug("Add Vendor Submitted", textBox);
-    VENDORS_API.addVendor(textBox).then((response) => {
-      if (response.status == 201) {
-        showSuccess();
-      } else {
-        showFailure();
-      }
-    });
+    let str: string[] = textBox.split(/\r?\n/);
+    str = str.filter((str) => /\S/.test(str));
+    for (let i = 0; i < str.length; i++) {
+      VENDORS_API.addVendor(str[i]);
+    }
     event.preventDefault();
   };
 
@@ -64,7 +62,7 @@ export default function VendorAdd() {
               setTextBox(e.currentTarget.value)
             }
             rows={8}
-            cols={30}
+            cols={40}
             className="text-base text-color surface-overlay p-2 border-1 border-solid surface-border border-round appearance-none outline-none focus:border-primary w-full"
           />
           <div className="flex flex-row justify-content-between card-container col-12">

--- a/frontend/src/pages/add/VendorAdd.tsx
+++ b/frontend/src/pages/add/VendorAdd.tsx
@@ -24,12 +24,19 @@ export default function VendorAdd() {
 
   const onSubmit = (event: FormEvent<HTMLFormElement>): void => {
     logger.debug("Add Vendor Submitted", textBox);
+    //take string input assigned to variable textBox and parse it based on newline character
+    //into a string array using a regular expression
     let str: string[] = textBox.split(/\r?\n/);
+    //take the string array -> check for and remove any elements containing only whitespace
+    //or nothing at all
     str = str.filter((str) => /\S/.test(str));
+    //loop through all elements and do an API submission to add the strings to database
     for (let i = 0; i < str.length; i++) {
       VENDORS_API.addVendor(str[i]).then((response) => {
         if (response.status == 201) {
           showSuccess();
+        } else {
+          showFailure();
         }
       });
     }

--- a/frontend/src/pages/add/VendorAdd.tsx
+++ b/frontend/src/pages/add/VendorAdd.tsx
@@ -27,7 +27,11 @@ export default function VendorAdd() {
     let str: string[] = textBox.split(/\r?\n/);
     str = str.filter((str) => /\S/.test(str));
     for (let i = 0; i < str.length; i++) {
-      VENDORS_API.addVendor(str[i]);
+      VENDORS_API.addVendor(str[i]).then((response) => {
+        if (response.status == 201) {
+          showSuccess();
+        }
+      });
     }
     event.preventDefault();
   };
@@ -57,6 +61,7 @@ export default function VendorAdd() {
           <InputTextarea
             id="addvendor"
             name="addvendor"
+            placeholder="Enter Multiple Vendors using Newline breaks"
             value={textBox}
             onChange={(e: FormEvent<HTMLTextAreaElement>) =>
               setTextBox(e.currentTarget.value)


### PR DESCRIPTION
## Feature Description (what did you do?)
Added functionality of more than one genre and vendor to the database. Also placeholder text for help.

## Design/Implementation Details (how did you do it?)
I created a parsing of a newline character based array break. Then elimnated empty or whitespace only text. Then i looped through and add each string to the database with a request.

## Areas Affected (what parts of the code does this affect?)
Vendor Add, GenreAdd, book Add

## Testing (how did you ensure this works correctly?)
Dev server

## Future Considerations (is there anything we should know about this going forward?)
It is difficult to show toast message for each addition requested as the responses overlap hiding some messages.
Maybe a backend only solution would be better.