### PR TITLE
[Backend] Add Cost Subtotal for Purchases & Sales

### DIFF
--- a/backend/purchase_orders/serializers.py
+++ b/backend/purchase_orders/serializers.py
@@ -11,13 +11,18 @@ class PurchaseSerializer(serializers.ModelSerializer):
     book = serializers.PrimaryKeyRelatedField(queryset=Book.objects.all())
     book_title = serializers.SerializerMethodField()
     id = serializers.IntegerField(required=False)
+    subtotal = serializers.SerializerMethodField()
 
     class Meta:
         model = Purchase
-        fields = ['id', 'book', 'book_title', 'quantity', 'unit_wholesale_price']
+        fields = ['id', 'book', 'book_title', 'quantity', 'unit_wholesale_price', 'subtotal']
 
     def get_book_title(self, instance):
         return instance.book.title
+    
+    def get_subtotal(self, instance):
+        return instance.quantity*instance.unit_wholesale_price
+
 
 class PurchaseOrderSerializer(serializers.ModelSerializer):
     purchases = PurchaseSerializer(many=True)

--- a/backend/purchase_orders/serializers.py
+++ b/backend/purchase_orders/serializers.py
@@ -21,7 +21,7 @@ class PurchaseSerializer(serializers.ModelSerializer):
         return instance.book.title
     
     def get_subtotal(self, instance):
-        return instance.quantity*instance.unit_wholesale_price
+        return float(format(instance.quantity*instance.unit_wholesale_price, '.2f'))
 
 
 class PurchaseOrderSerializer(serializers.ModelSerializer):

--- a/backend/sales/serializers.py
+++ b/backend/sales/serializers.py
@@ -11,6 +11,7 @@ class SaleSerializer(serializers.ModelSerializer):
     book = serializers.PrimaryKeyRelatedField(queryset=Book.objects.all())
     book_title = serializers.SerializerMethodField()
     id = serializers.IntegerField(required=False)
+    subtotal = serializers.SerializerMethodField()
 
     class Meta:
         model = Sale
@@ -18,6 +19,9 @@ class SaleSerializer(serializers.ModelSerializer):
     
     def get_book_title(self, instance):
         return instance.book.title
+
+    def get_subtotal(self, instance):
+        return instance.quantity*instance.unit_retail_price
 
 class SalesReconciliationSerializer(serializers.ModelSerializer):
     sales = SaleSerializer(many=True)

--- a/backend/sales/serializers.py
+++ b/backend/sales/serializers.py
@@ -15,13 +15,13 @@ class SaleSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Sale
-        fields = ['id', 'book', 'book_title', 'quantity', 'unit_retail_price']
+        fields = ['id', 'book', 'book_title', 'quantity', 'unit_retail_price', 'subtotal']
     
     def get_book_title(self, instance):
         return instance.book.title
 
     def get_subtotal(self, instance):
-        return instance.quantity*instance.unit_retail_price
+        return float(format(instance.quantity*instance.unit_retail_price, '.2f'))
 
 class SalesReconciliationSerializer(serializers.ModelSerializer):
     sales = SaleSerializer(many=True)


### PR DESCRIPTION
## Feature Description (what did you do?)
- Added Cost Subtotal for Purchase & Sale Serializers

## Design/Implementation Details (how did you do it?)
- This is a created field used in the frontend so no need to create a DB field - serializers.py
- Also the PO/SR is not sortable by subtotal of respective items because they do not need to be

## Areas Affected (what parts of the code does this affect?)
- Frontend Endpoint API

## Testing (how did you ensure this works correctly?)
- Postman

## Future Considerations (is there anything we should know about this going forward?)
