### PR TITLE
[BugFix] Genre Book Counts IsGhost Books

### DIFF
--- a/backend/genres/views.py
+++ b/backend/genres/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Count
+from django.db.models import Count, Q
 
 from rest_framework import filters, status
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
@@ -53,9 +53,9 @@ class ListCreateGenreAPIView(ListCreateAPIView):
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(request, self.get_queryset())
 
-        # Might not scale?
+        # https://docs.djangoproject.com/en/4.1/topics/db/aggregation/#filtering-on-annotations
         queryset = queryset.annotate(
-            book_cnt=Count('book')
+            book_cnt=Count('book', filter=Q(book__isGhost=False))
         )
 
         page = self.paginate_queryset(queryset)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   frontend:
     image: frontend-image
     build: ./frontend
+    restart: always
     ports: 
       - 3000:3000
     environment:
@@ -19,5 +20,6 @@ services:
   backend:
     image: backend-image
     build: ./backend
+    restart: always
     ports: 
       - 8000:8000


### PR DESCRIPTION
## Feature Description (what did you do?)
- Filtered Books that are not ghost to be counted in Genre (Closes #179)

## Design/Implementation Details (how did you do it?)
- Added a Q Filter to annotation on book_cnt - views.py

## Areas Affected (what parts of the code does this affect?)
- Display correct data on website

## Testing (how did you ensure this works correctly?)
- Postman

## Future Considerations (is there anything we should know about this going forward?)
