### PR TITLE
Update Regex to Allow CORS policy from localhost and books-front.colab.duke.edu

### DIFF
--- a/backend/hypothetical_books_backend/settings.py
+++ b/backend/hypothetical_books_backend/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 from pathlib import Path
 from datetime import timedelta
-from corsheaders.defaults import default_headers
 import environ
 import os
 

--- a/backend/hypothetical_books_backend/settings.py
+++ b/backend/hypothetical_books_backend/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 
 from pathlib import Path
 from datetime import timedelta
+from corsheaders.defaults import default_headers
 import environ
 import os
 
@@ -175,7 +176,7 @@ AUTH_USER_MODEL = 'authapp.User'
 
 CORS_ALLOW_ALL_ORIGINS = False
 CORS_ALLOWED_ORIGIN_REGEXES = [
-    '^https?://localhost(:8000)?$'
+    '^https?://localhost(:8000)?$',
     '^https?://books-front\.colab\.duke\.edu(:3000)?$' # Matches http,https request from port 3000 or none
 ]
 

--- a/backend/hypothetical_books_backend/settings.py
+++ b/backend/hypothetical_books_backend/settings.py
@@ -173,9 +173,10 @@ APPEND_SLASH = False
 # called `INSTALLED_APPS`.
 AUTH_USER_MODEL = 'authapp.User'
 
-CORS_ORIGIN_ALLOW_ALL = False
-CORS_ORIGIN_WHITELIST = [
-    'http://localhost',
+CORS_ALLOW_ALL_ORIGINS = False
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    '^https?://localhost(:8000)?$'
+    '^https?://books-front\.colab\.duke\.edu(:3000)?$' # Matches http,https request from port 3000 or none
 ]
 
 SIMPLE_JWT = {


### PR DESCRIPTION
## Feature Description (what did you do?)
Added CORS_ALLOWED_ORIGIN_REGEXES to allow strings:

http://localhost/
https://localhost/
http://localhost:8000/
https://localhost:8000/

http://books-front.colab.duke.edu/
https://books-front.colab.duke.edu/
http://books-front.colab.duke.edu:3000/
https://books-front.colab.duke.edu:3000/

(Closes #199 )

## Design/Implementation Details (how did you do it?)
CORS_ALLOWED_ORIGIN_REGEXES = [
'^https?://localhost(:8000)?$'
'^https?://books-front.colab.duke.edu(:3000)?$' # Matches http,https request from port 3000 or none
]

## Areas Affected (what parts of the code does this affect?)
- Frontend CORS Policy allowed

## Testing (how did you ensure this works correctly?)

## Future Considerations (is there anything we should know about this going forward?)
