### PR TITLE
Shelf calculator

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -20,6 +20,11 @@ function NavigationBar() {
           icon: "pi pi-fw pi-plus",
           command: () => navigate("/books/add"),
         },
+        {
+          label: "Shelf Calculator",
+          icon: "pi pi-fw pi-calculator",
+          command: () => navigate("/books/shelf-calculator"),
+        },
       ],
     },
     {

--- a/frontend/src/components/Router.tsx
+++ b/frontend/src/components/Router.tsx
@@ -18,6 +18,7 @@ import PurchaseOrderList from "../pages/list/POList";
 import PasswordChangePage from "../pages/auth/PasswordChange";
 import SalesReportPage from "../pages/list/SalesReport";
 import GoToLoginPageIfNotLoggedIn from "../util/AuthCheck";
+import ShelfCalculator from "../pages/ShelfCalculator";
 
 const WithNavBar = () => {
   return (
@@ -56,6 +57,7 @@ export default function Router() {
         <Route path="vendors" element={<VendorList />} />
         <Route path="books/add" element={<BookAdd />} />
         <Route path="books/detail/:id" element={<ModifyBook />} />
+        <Route path="books/shelf-calculator" element={<ShelfCalculator />} />
         <Route path="genres/add" element={<GenreAdd />} />
         <Route path="genres/detail/:id" element={<GenreDetail />} />
         <Route path="purchase-orders/add" element={<ModifyPO />} />

--- a/frontend/src/components/buttons/AddRowButton.tsx
+++ b/frontend/src/components/buttons/AddRowButton.tsx
@@ -16,8 +16,9 @@ interface AddRowButtonProps<T extends IDer> {
 export default function AddRowButton<T extends IDer>(
   props: AddRowButtonProps<T>
 ) {
+  const [lineData, setLineData] = useState<T>(props.emptyItem);
+
   const addNewRow = () => {
-    const [lineData, setLineData] = useState<T>(props.emptyItem);
     setLineData(props.emptyItem);
     const _lineData = lineData;
     _lineData.id = uuid();
@@ -34,7 +35,7 @@ export default function AddRowButton<T extends IDer>(
       icon="pi pi-plus"
       className="p-button-info mr-2"
       onClick={addNewRow}
-      disabled={!props.isModifiable ?? false}
+      disabled={!!props.isModifiable}
     />
   );
 }

--- a/frontend/src/components/buttons/AddRowButton.tsx
+++ b/frontend/src/components/buttons/AddRowButton.tsx
@@ -1,0 +1,40 @@
+import { Button } from "primereact/button";
+import { useState } from "react";
+import { v4 as uuid } from "uuid";
+
+interface IDer {
+  id: string | number;
+}
+
+interface AddRowButtonProps<T extends IDer> {
+  emptyItem: T;
+  rows: T[];
+  setRows: (items: T[]) => void;
+  isModifiable?: boolean;
+}
+
+export default function AddRowButton<T extends IDer>(
+  props: AddRowButtonProps<T>
+) {
+  const addNewRow = () => {
+    const [lineData, setLineData] = useState<T>(props.emptyItem);
+    setLineData(props.emptyItem);
+    const _lineData = lineData;
+    _lineData.id = uuid();
+    setLineData(_lineData);
+    const _data = [...props.rows];
+    _data.push({ ...lineData });
+    props.setRows(_data);
+  };
+
+  return (
+    <Button
+      type="button"
+      label="New"
+      icon="pi pi-plus"
+      className="p-button-info mr-2"
+      onClick={addNewRow}
+      disabled={!props.isModifiable ?? false}
+    />
+  );
+}

--- a/frontend/src/components/dropdowns/DisplayModeDropdown.tsx
+++ b/frontend/src/components/dropdowns/DisplayModeDropdown.tsx
@@ -18,7 +18,6 @@ export default function DisplayModeDropdown(props: DisplayModeDropdownProps) {
     <Dropdown
       value={props.selectedDisplayMode}
       options={displayModeList}
-      appendTo={"self"}
       onChange={(e) => props.setSelectedDisplayMode(e.value)}
       placeholder={"Select Display Mode"}
     />

--- a/frontend/src/components/dropdowns/DisplayModeDropdown.tsx
+++ b/frontend/src/components/dropdowns/DisplayModeDropdown.tsx
@@ -1,0 +1,26 @@
+import { Dropdown } from "primereact/dropdown";
+
+export enum DisplayMode {
+  COVER_OUT = "Cover Out",
+  SPINE_OUT = "Spine Out",
+}
+
+const displayModeList = Object.values(DisplayMode);
+
+export interface DisplayModeDropdownProps {
+  setSelectedDisplayMode: (arg0: DisplayMode) => void;
+  selectedDisplayMode: DisplayMode;
+}
+
+// This cannot be used in a table cell in the current form, only when there is one on the page
+export default function DisplayModeDropdown(props: DisplayModeDropdownProps) {
+  return (
+    <Dropdown
+      value={props.selectedDisplayMode}
+      options={displayModeList}
+      appendTo={"self"}
+      onChange={(e) => props.setSelectedDisplayMode(e.value)}
+      placeholder={"Select Display Mode"}
+    />
+  );
+}

--- a/frontend/src/pages/ShelfCalculator.tsx
+++ b/frontend/src/pages/ShelfCalculator.tsx
@@ -15,6 +15,7 @@ import AddRowButton from "../components/buttons/AddRowButton";
 import { DataTable } from "primereact/datatable";
 import { Toolbar } from "primereact/toolbar";
 import { Column } from "primereact/column";
+import { calculateTotalForField } from "../util/CalculateTotal";
 
 const DEFAULT_WIDTH = 5;
 const DEFAULT_HEIGHT = 8;
@@ -148,6 +149,7 @@ export default function ShelfCalculator() {
       row.maxDisplayCount = calculateMaxDisplayCount(row);
       row.displayCount = calculateMaxDisplayCount(row);
       row.shelfSpace = calculateShelfSpace(row);
+      updateTotalShelfSpace(draft);
     });
   };
 
@@ -159,6 +161,7 @@ export default function ShelfCalculator() {
       const row = findById(draft, rowData.id)!;
       row.displayCount = newDisplayCount;
       row.shelfSpace = calculateShelfSpace(row);
+      updateTotalShelfSpace(draft);
     });
   };
 
@@ -172,7 +175,13 @@ export default function ShelfCalculator() {
       row.maxDisplayCount = calculateMaxDisplayCount(row);
       row.displayCount = calculateCurrentDisplayCount(row);
       row.shelfSpace = calculateShelfSpace(row);
+      updateTotalShelfSpace(draft);
     });
+  };
+
+  const updateTotalShelfSpace = (rows: ShelfCalculatorRow[]) => {
+    const total = rows.reduce((total, item) => total + item.shelfSpace, 0);
+    setTotalShelfSpace(total);
   };
 
   // Dropdowns
@@ -239,7 +248,11 @@ export default function ShelfCalculator() {
             </h1>
           </div>
 
-          <Toolbar className="mb-4" left={rowAddButton} />
+          <Toolbar
+            className="mb-4"
+            left={rowAddButton}
+            right={`Total Shelf Space: ${totalShelfSpace}`}
+          />
           <DataTable
             showGridlines
             value={rows}

--- a/frontend/src/pages/ShelfCalculator.tsx
+++ b/frontend/src/pages/ShelfCalculator.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { useImmer } from "use-immer";
+import BooksDropdown, {
+  BooksDropdownData,
+} from "../components/dropdowns/BookDropdown";
+import DisplayModeDropdown, {
+  DisplayMode,
+} from "../components/dropdowns/DisplayModeDropdown";
+import { createColumns, TableColumn } from "../components/TableColumns";
+import { filterById, findById } from "../util/IDOperations";
+import { numberEditor } from "../util/TableCellEditFuncs";
+import { Book } from "./list/BookList";
+import { v4 as uuid } from "uuid";
+import { DeleteTemplate } from "../util/EditDeleteTemplate";
+import AddRowButton from "../components/buttons/AddRowButton";
+import { DataTable } from "primereact/datatable";
+import { Toolbar } from "primereact/toolbar";
+import { Column } from "primereact/column";
+
+const DEFAULT_HEIGHT = 8;
+const DEFAULT_WIDTH = 5;
+const DEFAULT_THICKNESS = 0.8;
+
+interface ShelfCalculatorRow {
+  id: string;
+  bookTitle: string;
+  stock: number;
+  displayCount: number;
+  displayMode: DisplayMode;
+  shelfSpace: number;
+  hasUnknownDimensions: boolean;
+}
+
+const emptyRow: ShelfCalculatorRow = {
+  id: "",
+  bookTitle: "",
+  stock: 0,
+  displayCount: 0,
+  displayMode: DisplayMode.COVER_OUT,
+  shelfSpace: 0,
+  hasUnknownDimensions: false,
+};
+
+export default function ShelfCalculator() {
+  const [rows, setRows] = useImmer<ShelfCalculatorRow[]>([]);
+  const [totalShelfSpace, setTotalShelfSpace] = useState<number>(0);
+
+  // For dropdown menus
+  const [booksMap, setBooksMap] = useState<Map<string, Book>>(new Map());
+  const [booksDropdownTitles, setBooksDropdownTitles] = useState<string[]>([]);
+
+  const COLUMNS: TableColumn[] = [
+    {
+      field: "bookTitle",
+      header: "Book",
+      customBody: (rowData: ShelfCalculatorRow) =>
+        booksDropDownEditor(rowData.bookTitle, (newValue) => {
+          handleBookChange(rowData, newValue);
+        }),
+    },
+    {
+      field: "stock",
+      header: "Current Inventory",
+    },
+    {
+      field: "displayCount",
+      header: "Display Count",
+      customBody: (rowData: ShelfCalculatorRow) =>
+        numberEditor(rowData.displayCount, (newValue) => {
+          handleDisplayCountChange(rowData, newValue);
+        }),
+    },
+    {
+      field: "displayMode",
+      header: "Display Count",
+      customBody: (rowData: ShelfCalculatorRow) =>
+        numberEditor(rowData.displayCount, (newValue) => {
+          handleDisplayCountChange(rowData, newValue);
+        }),
+    },
+    {
+      field: "shelfSpace",
+      header: "Shelf Space",
+    },
+  ];
+
+  // Handlers for when data is changed
+
+  const handleBookChange = (
+    rowData: ShelfCalculatorRow,
+    newBookTitle: string
+  ) => {
+    setRows((draft) => {
+      const row = findById(draft, rowData.id);
+    });
+  };
+
+  const handleDisplayCountChange = (
+    rowData: ShelfCalculatorRow,
+    newDisplayCount: number
+  ) => {
+    setRows((draft) => {
+      const row = findById(draft, rowData.id);
+    });
+  };
+
+  const handleDisplayModeChange = (
+    rowData: ShelfCalculatorRow,
+    newDisplayMode: DisplayMode
+  ) => {
+    setRows((draft) => {
+      const row = findById(draft, rowData.id);
+    });
+  };
+
+  // Dropdowns
+
+  // Get the data for the books dropdown
+  useEffect(
+    () =>
+      BooksDropdownData({
+        setBooksMap: setBooksMap,
+        setBookTitlesList: setBooksDropdownTitles,
+      }),
+    []
+  );
+
+  // The books dropdown
+  const booksDropDownEditor = (
+    value: string,
+    onChange: (newValue: string) => void
+  ) => (
+    <BooksDropdown
+      setSelectedBook={onChange}
+      selectedBook={value}
+      bookTitlesList={booksDropdownTitles}
+      placeholder={value}
+    />
+  );
+
+  // The display mode dropdown
+  const displayModeDropdownEditor = (
+    value: DisplayMode,
+    onChange: (newValue: DisplayMode) => void
+  ) => (
+    <DisplayModeDropdown
+      setSelectedDisplayMode={onChange}
+      selectedDisplayMode={value}
+    />
+  );
+
+  // Delete icon for each row
+  const rowDeleteButton = DeleteTemplate<ShelfCalculatorRow>({
+    onDelete: (rowData) => filterById(rows, rowData.id, setRows),
+  });
+
+  // Button for adding a new row
+  const rowAddButton = AddRowButton<ShelfCalculatorRow>({
+    emptyItem: emptyRow,
+    setRows: setRows,
+    rows: rows,
+  });
+
+  const columns = createColumns(COLUMNS);
+
+  return (
+    <div>
+      <div className="grid flex justify-content-center">
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/primeflex@3.1.2/primeflex.css"
+        ></link>
+        <div className="col-11">
+          <div className="pt-2">
+            <h1 className="p-component p-text-secondary text-5xl text-center text-900 color: var(--surface-800);">
+              Shelf Calculator
+            </h1>
+          </div>
+
+          <Toolbar className="mb-4" left={rowAddButton} />
+          <DataTable
+            showGridlines
+            value={rows}
+            className="editable-cells-table"
+            responsiveLayout="scroll"
+            editMode="cell"
+          >
+            {columns}
+            <Column
+              body={rowDeleteButton}
+              exportable={false}
+              style={{ minWidth: "8rem" }}
+            ></Column>
+          </DataTable>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/detail/PODetail.tsx
+++ b/frontend/src/pages/detail/PODetail.tsx
@@ -46,7 +46,7 @@ import {
 } from "./errors/CSVImportErrors";
 import { Book } from "../list/BookList";
 import { useImmer } from "use-immer";
-import { findById } from "../../util/FindBy";
+import { findById } from "../../util/IDOperations";
 import { calculateTotal } from "../../util/CalculateTotal";
 
 export interface POPurchaseRow {

--- a/frontend/src/pages/detail/SRDetail.tsx
+++ b/frontend/src/pages/detail/SRDetail.tsx
@@ -97,7 +97,9 @@ export default function SRDetail() {
           setSales(salesReconciliation.sales);
           setTotalRevenue(salesReconciliation.totalRevenue);
         })
-        .catch(() => showFailure(toast, "Could not fetch purchase order data"));
+        .catch(() =>
+          showFailure(toast, "Could not fetch sales reconciliation data")
+        );
     }
   }, []);
 
@@ -114,9 +116,9 @@ export default function SRDetail() {
       customBody: (rowData: SRSaleRow) =>
         booksDropDownEditor(rowData.bookTitle, (newValue) => {
           setSales((draft) => {
-            const purchase = findById(draft, rowData.id);
-            purchase!.bookTitle = newValue;
-            purchase!.price = booksMap.get(newValue)!.retailPrice;
+            const sale = findById(draft, rowData.id);
+            sale!.bookTitle = newValue;
+            sale!.price = booksMap.get(newValue)!.retailPrice;
             setTotalRevenue(calculateTotal(draft));
           });
         }),
@@ -128,8 +130,8 @@ export default function SRDetail() {
       customBody: (rowData: SRSaleRow) =>
         numberEditor(rowData.quantity, (newValue) => {
           setSales((draft) => {
-            const purchase = findById(draft, rowData.id);
-            purchase!.quantity = newValue;
+            const sale = findById(draft, rowData.id);
+            sale!.quantity = newValue;
             setTotalRevenue(calculateTotal(draft));
           });
         }),
@@ -140,8 +142,8 @@ export default function SRDetail() {
       customBody: (rowData: SRSaleRow) =>
         priceEditor(rowData.price, (newValue) => {
           setSales((draft) => {
-            const purchase = findById(draft, rowData.id);
-            purchase!.price = newValue;
+            const sale = findById(draft, rowData.id);
+            sale!.price = newValue;
             setTotalRevenue(calculateTotal(draft));
           });
         }),

--- a/frontend/src/pages/detail/SRDetail.tsx
+++ b/frontend/src/pages/detail/SRDetail.tsx
@@ -45,7 +45,7 @@ import {
 } from "./errors/CSVImportErrors";
 import { Book } from "../list/BookList";
 import { useImmer } from "use-immer";
-import { findById } from "../../util/FindBy";
+import { findById } from "../../util/IDOperations";
 import { calculateTotal } from "../../util/CalculateTotal";
 
 export interface SRSaleRow {
@@ -270,7 +270,7 @@ export default function SRDetail() {
   // Toast is used for showing success/error messages
   const toast = useRef<Toast>(null);
 
-  const actionBodyTemplate = (rowData: SRSaleRow) => {
+  const rowDeleteButton = (rowData: SRSaleRow) => {
     return (
       <React.Fragment>
         <Button
@@ -439,7 +439,7 @@ export default function SRDetail() {
             >
               {columns}
               <Column
-                body={actionBodyTemplate}
+                body={rowDeleteButton}
                 exportable={false}
                 style={{ minWidth: "8rem" }}
               ></Column>

--- a/frontend/src/util/EditDeleteTemplate.tsx
+++ b/frontend/src/util/EditDeleteTemplate.tsx
@@ -1,10 +1,32 @@
 import { Button } from "primereact/button";
 import React from "react";
 
+// This will be removed soon, as we will no longer have edit buttons
 interface EditDeleteTemplateProps<T> {
   onEdit: (arg0: T) => void;
   onDelete: (arg0: T) => void;
   deleteDisabled: (arg0: T) => boolean;
+}
+
+interface DeleteTemplateProps<T> {
+  onDelete: (arg0: T) => void;
+  deleteDisabled?: (arg0: T) => boolean;
+}
+
+export function DeleteTemplate<T>(props: DeleteTemplateProps<T>) {
+  return (rowData: T) => {
+    return (
+      <React.Fragment>
+        <Button
+          type="button"
+          icon="pi pi-trash"
+          className="p-button-rounded p-button-danger"
+          onClick={() => props.onDelete(rowData)}
+          disabled={props.deleteDisabled?.(rowData) ?? false}
+        />
+      </React.Fragment>
+    );
+  };
 }
 
 export default function EditDeleteTemplate<T>(

--- a/frontend/src/util/FindBy.tsx
+++ b/frontend/src/util/FindBy.tsx
@@ -1,7 +1,0 @@
-interface IDer {
-  id: string | number;
-}
-
-export function findById<T extends IDer>(array: T[], id: string | number) {
-  return array.find((element) => element.id === id);
-}

--- a/frontend/src/util/IDOperations.tsx
+++ b/frontend/src/util/IDOperations.tsx
@@ -1,0 +1,17 @@
+interface IDer {
+  id: string | number;
+}
+
+export function findById<T extends IDer>(array: T[], id: string | number) {
+  return array.find((element) => element.id === id);
+}
+
+// Remove the ID from the array
+export function filterById<T extends IDer>(
+  array: T[],
+  id: string | number,
+  setArray: (array: T[]) => void
+) {
+  const newData = array.filter((element) => element.id !== id);
+  setArray(newData);
+}

--- a/frontend/src/util/TableCellEditFuncs.tsx
+++ b/frontend/src/util/TableCellEditFuncs.tsx
@@ -36,11 +36,14 @@ export function textEditor(options: ColumnEditorOptions) {
 
 export function numberEditor(
   value: number,
-  onChange: (newValue: number) => void
+  onChange: (newValue: number) => void,
+  min?: number,
+  max?: number
 ) {
   return (
     <InputNumber
-      min={1}
+      min={min ?? 1}
+      max={max}
       value={value}
       onValueChange={(e) => onChange(e.target.value ?? 1)}
       mode="decimal"


### PR DESCRIPTION
## Feature Description/Implementation

Implemented the shelf calculator. Basically just had to create a table/toolbar in the same way that we already have many times, but had to add a bunch of restrictions based on stock/display mode. I generalized some of our behavior (like the add line item button) to try and clean up the code, but the SR/PO detail pages still use the old versions

## Dependencies

## Everything Else
