### PR TITLE
Fix Buyback and Sales Check for Previous Purchase

### DIFF
--- a/backend/buybacks/serializers.py
+++ b/backend/buybacks/serializers.py
@@ -72,9 +72,11 @@ class BuybackOrderSerializer(TransactionGroupBaseSerializer):
                 raise serializers.ValidationError(f"Not enough books in stock to buyback {book_to_buyback.title}")
 
     def __book_has_previous_purchase(self, date, book_id):
+        print(Purchase.objects.filter(book=book_id).distinct('purchase_order').values('book', 'purchase_order'))
         try:
-            return PurchaseOrder.objects.filter(date__lte=date).annotate(prev_purchase=Subquery(Purchase.objects.filter(purchase_order=OuterRef('id')).filter(
-                book=book_id).values('book'))).values('prev_purchase').exclude(prev_purchase=None).first()['prev_purchase'] != None
+            return PurchaseOrder.objects.filter(date__lte=date).annotate(
+                prev_purchase=Subquery(Purchase.objects.filter(purchase_order=OuterRef('id')).filter(book=book_id).distinct('purchase_order').values('book'))).values('prev_purchase').exclude(
+                    prev_purchase=None).first()['prev_purchase'] != None
         except TypeError:
             return None
 

--- a/backend/sales/serializers.py
+++ b/backend/sales/serializers.py
@@ -65,8 +65,9 @@ class SalesReconciliationSerializer(TransactionGroupBaseSerializer):
 
     def __book_has_previous_purchase(self, date, book_id):
         try:
-            return PurchaseOrder.objects.filter(date__lte=date).annotate(prev_purchase=Subquery(Purchase.objects.filter(purchase_order=OuterRef('id')).filter(
-                book=book_id).values('book'))).values('prev_purchase').exclude(prev_purchase=None).first()['prev_purchase'] != None
+            return PurchaseOrder.objects.filter(date__lte=date).annotate(
+                prev_purchase=Subquery(Purchase.objects.filter(purchase_order=OuterRef('id')).filter(book=book_id).distinct('purchase_order').values('book'))).values('prev_purchase').exclude(
+                    prev_purchase=None).first()['prev_purchase'] != None
         except TypeError:
             return None
 


### PR DESCRIPTION
## Feature Description/Implementation
Bugfix: When checking for a book having a previous purchase, if the purchase order has multiple purchases of that book, the subquery returns multiple values, yielding an error. Fixed to only return one now
## Dependencies

## Everything Else
