### PR TITLE
Remove clear from books dropdown

### DIFF
--- a/frontend/src/components/dropdowns/BookDropdown.tsx
+++ b/frontend/src/components/dropdowns/BookDropdown.tsx
@@ -41,7 +41,6 @@ export default function BooksDropdown(props: BookDropdownProps) {
       onChange={(e) => {
         props.setSelectedBook(e.value);
       }}
-      showClear
       style={{
         width: "30rem",
       }}


### PR DESCRIPTION
## Feature Description/Implementation

Was causing the page to crash due to trying to get data for a book that doesn't exist. Easiest to just remove it, since they can delete the row if they don't want a book


## Dependencies

## Everything Else
