### PR TITLE
Create permissions for limiting body size to 1 MB and only allowing requests from book hook IP

### DIFF
--- a/backend/sales/sales_record_permissions.py
+++ b/backend/sales/sales_record_permissions.py
@@ -1,0 +1,15 @@
+from rest_framework import permissions
+
+
+class SalesRecordsWhitelistPermission(permissions.BasePermission):
+
+    def has_permission(self, request, view):
+        return request.META["REMOTE_ADDR"] == "152.3.54.108"
+
+
+class BodySizePermission(permissions.BasePermission):
+    message = "Body must be under 1MB."
+    code = 413
+
+    def has_permission(self, request, view):
+        return int(request.META["CONTENT_LENGTH"]) <= 1024 * 1024

--- a/backend/sales/urls.py
+++ b/backend/sales/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
-from .views import ListCreateSalesReconciliationAPIView, RetrieveUpdateDestroySalesReconciliationAPIView, RetrieveSalesReportAPIView, CSVSaleAPIView
+from .views import ListSalesRecordAPIView, CreateSalesRecordAPIView, RetrieveUpdateDestroySalesReconciliationAPIView, RetrieveSalesReportAPIView, CSVSaleAPIView
 
 app_name = 'sales'
 
 urlpatterns = [
-    path('/sales_reconciliation', ListCreateSalesReconciliationAPIView.as_view()),
+    path('/sales_reconciliation', ListSalesRecordAPIView.as_view()),
+    path('/sales_record', CreateSalesRecordAPIView.as_view()),
     path('/sales_reconciliation/<id>', RetrieveUpdateDestroySalesReconciliationAPIView.as_view()),
     path('/sales_report/start:<start_date>end:<end_date>', RetrieveSalesReportAPIView.as_view()),
     path('/sales_reconciliation/csv/import', CSVSaleAPIView.as_view()),

--- a/backend/sales/views.py
+++ b/backend/sales/views.py
@@ -18,10 +18,12 @@ from helpers.csv_reader import CSVReader
 from buybacks.models import BuybackOrder
 from utils.permissions import CustomBasePermission
 from .parsers import XMLParser
+from .sales_record_permissions import SalesRecordsWhitelistPermission, BodySizePermission
 
 
 class ListCreateSalesReconciliationAPIView(ListCreateAPIView):
-    # permission_classes = [CustomBasePermission]
+    permission_classes = [SalesRecordsWhitelistPermission, BodySizePermission]
+    authentication_classes = []
     serializer_class = SalesReconciliationSerializer
     queryset = SalesReconciliation.objects.all()
     pagination_class = SalesReconciliationPagination


### PR DESCRIPTION
Tested that they both work simultaneously by changing the IP to my own IP, and sending a request. The request receives the expected 413 error of size too large. Without changing the IP, it correctly receives 403 Forbidden error
## Feature Description/Implementation

## Dependencies
This is dependent upon the assumption that book  hook has a static IP address. Can wait to confirm this before merging if we want. Also this restriction, once merged, will make committing heinous crimes against this endpoint harder for testing, so might want to hold off on merging until we are confident it is totally robust
## Everything Else
