### PR TITLE
[Front-End] Submit Button Disable for all Add Pages

### DIFF
--- a/frontend/src/pages/books/BookAdd.tsx
+++ b/frontend/src/pages/books/BookAdd.tsx
@@ -450,6 +450,7 @@ export default function BookAdd() {
                   name="addbooksubmission"
                   label="Lookup"
                   type="submit"
+                  disabled={textBox.length == 0}
                   icon
                   className="p-button-success"
                 />
@@ -493,6 +494,7 @@ export default function BookAdd() {
                 id="confirmbooks"
                 name="confirmbooks"
                 label="Submit"
+                disabled={books.length == 0}
                 className="p-button-success p-button-raised"
                 type="submit"
               />

--- a/frontend/src/pages/buybacks/BBDetail.tsx
+++ b/frontend/src/pages/buybacks/BBDetail.tsx
@@ -218,6 +218,15 @@ export default function BBDetail() {
     return true;
   };
 
+  const resetPageInputFields = () => {
+    setSelectedVendorName("");
+    setBuybacks([]);
+    setDate(new Date());
+    setTotalRevenue(0);
+    setHasUploadedCSV(false);
+    setIsGoBackActive(false);
+  };
+
   const onSubmit = (): void => {
     if (!validateSubmission()) {
       return;
@@ -249,7 +258,7 @@ export default function BBDetail() {
     BUYBACK_API.addBuyBack(buyBack)
       .then(() => {
         showSuccess(toast, "Book Buyback added successfully");
-        isGoBackActive ? navigate("/book-buybacks") : window.location.reload();
+        isGoBackActive ? navigate("/book-buybacks") : resetPageInputFields();
       })
       .catch((error) => {
         showFailure(
@@ -375,6 +384,10 @@ export default function BBDetail() {
     />
   );
 
+  const checkForNecessaryValues = (): boolean => {
+    return buybacks.length == 0 || selectedVendorName === "";
+  };
+
   // Right
   const submitButton = (
     <ConfirmPopup
@@ -383,7 +396,7 @@ export default function BBDetail() {
       hideFunc={() => setIsConfirmationPopupVisible(false)}
       onFinalSubmission={onSubmit}
       onShowPopup={() => setIsConfirmationPopupVisible(true)}
-      disabled={!isModifiable}
+      disabled={!isModifiable || checkForNecessaryValues()}
       label={"Submit"}
       className="p-button-success ml-2"
     />
@@ -402,7 +415,7 @@ export default function BBDetail() {
         setIsConfirmationPopupVisible(true);
         setIsGoBackActive(true);
       }}
-      disabled={!isModifiable}
+      disabled={!isModifiable || checkForNecessaryValues()}
       label={"Submit and Go Back"}
       className="p-button-success ml-2"
     />

--- a/frontend/src/pages/genres/GenreAdd.tsx
+++ b/frontend/src/pages/genres/GenreAdd.tsx
@@ -14,6 +14,11 @@ export default function GenreAdd() {
   const [textBox, setTextBox] = useState<string>("");
   const [isGoBackActive, setIsGoBackActive] = useState<boolean>(false);
 
+  const resetPageInputFields = () => {
+    setTextBox("");
+    setIsGoBackActive(false);
+  };
+
   // Toast is used for showing success/error messages
   const toast = useRef<Toast>(null);
 
@@ -36,7 +41,7 @@ export default function GenreAdd() {
     axios
       .all(genreRequests)
       .then(() => {
-        isGoBackActive ? navigate("/genres") : setTextBox("");
+        isGoBackActive ? navigate("/genres") : resetPageInputFields();
       })
       .catch(() => {
         showFailure(toast, "One or more of the genres failed to add");

--- a/frontend/src/pages/genres/GenreAdd.tsx
+++ b/frontend/src/pages/genres/GenreAdd.tsx
@@ -36,7 +36,7 @@ export default function GenreAdd() {
     axios
       .all(genreRequests)
       .then(() => {
-        isGoBackActive ? navigate("/genres") : window.location.reload();
+        isGoBackActive ? navigate("/genres") : setTextBox("");
       })
       .catch(() => {
         showFailure(toast, "One or more of the genres failed to add");
@@ -95,11 +95,13 @@ export default function GenreAdd() {
             <Button
               label="Submit"
               type="submit"
+              disabled={textBox.length == 0}
               className="p-button-success p-button-raised"
             />
             <Button
               label="Submit and Go Back"
               type="submit"
+              disabled={textBox.length == 0}
               onClick={() => setIsGoBackActive(true)}
               className="p-button-success p-button-raised"
             />

--- a/frontend/src/pages/purchases/PODetail.tsx
+++ b/frontend/src/pages/purchases/PODetail.tsx
@@ -193,6 +193,15 @@ export default function PODetail() {
     return true;
   };
 
+  const resetPageInputFields = () => {
+    setSelectedVendorName("");
+    setPurchases([]);
+    setDate(new Date());
+    setTotalCost(0);
+    setHasUploadedCSV(false);
+    setIsGoBackActive(false);
+  };
+
   // On submission of the PO, we either add/edit depending on the page type
   const onSubmit = (): void => {
     if (!validateSubmission()) {
@@ -225,9 +234,7 @@ export default function PODetail() {
     PURCHASES_API.addPurchaseOrder(purchaseOrder)
       .then(() => {
         showSuccess(toast, "Purchase order added successfully");
-        isGoBackActive
-          ? navigate("/purchase-orders")
-          : window.location.reload();
+        isGoBackActive ? navigate("/purchase-orders") : resetPageInputFields();
       })
       .catch(() => showFailure(toast, "Could not add purchase order"));
   }
@@ -359,6 +366,10 @@ export default function PODetail() {
     />
   );
 
+  const checkForNecessaryValues = (): boolean => {
+    return purchases.length == 0 || selectedVendorName === "";
+  };
+
   // Right
   const submitButton = (
     <ConfirmPopup
@@ -367,7 +378,7 @@ export default function PODetail() {
       hideFunc={() => setIsConfirmationPopupVisible(false)}
       onFinalSubmission={onSubmit}
       onShowPopup={() => setIsConfirmationPopupVisible(true)}
-      disabled={!isModifiable}
+      disabled={!isModifiable || checkForNecessaryValues()}
       label={"Submit"}
       className="p-button-success ml-2"
     />
@@ -386,7 +397,7 @@ export default function PODetail() {
         setIsConfirmationPopupVisible(true);
         setIsGoBackActive(true);
       }}
-      disabled={!isModifiable}
+      disabled={!isModifiable || checkForNecessaryValues()}
       label={"Submit and Go Back"}
       className="p-button-success ml-2"
     />

--- a/frontend/src/pages/vendors/VendorAdd.tsx
+++ b/frontend/src/pages/vendors/VendorAdd.tsx
@@ -65,6 +65,11 @@ export default function VendorAdd() {
     },
   ];
 
+  const resetPageInputFields = () => {
+    setVendors([]);
+    setIsGoBackActive(false);
+  };
+
   // The navigator to switch pages
   const navigate = useNavigate();
 
@@ -84,7 +89,7 @@ export default function VendorAdd() {
     axios
       .all(vendorRequests)
       .then(() => {
-        isGoBackActive ? navigate("/vendors") : window.location.reload();
+        isGoBackActive ? navigate("/vendors") : resetPageInputFields();
       })
       .catch(() => {
         showFailure(toast, "One or more of the vendors failed to add");

--- a/frontend/src/pages/vendors/VendorAdd.tsx
+++ b/frontend/src/pages/vendors/VendorAdd.tsx
@@ -111,6 +111,7 @@ export default function VendorAdd() {
       onShowPopup={() => setIsConfirmationPopupVisible(true)}
       label={"Submit"}
       className="p-button-success ml-2"
+      disabled={vendors.length == 0}
     />
   );
 
@@ -128,6 +129,7 @@ export default function VendorAdd() {
       }}
       label={"Submit and Go Back"}
       className="p-button-success ml-2"
+      disabled={vendors.length == 0}
     />
   );
 


### PR DESCRIPTION
## Feature Description/Implementation
This disables the submit button for all add pages if there is no information or there is missing information when trying to do the add request. otherwise it works, and enables it to allow user submission.
#482 
#483 
## Dependencies

## Everything Else
