### PR TITLE
Fixed save-as then save bug on bookcase detail

### DIFF
--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 import { Toast } from "primereact/toast";
 
 export const showSuccess = (toast: React.RefObject<Toast>, message: string) => {
-  toast.current?.show({ severity: "success", summary: message });
+  toast.current?.show({ severity: "success", summary: message, life: 2000 });
 };
 
 export const showWarning = (toast: React.RefObject<Toast>, message: string) => {

--- a/frontend/src/pages/casedesigner/detail/BookcaseDetail.tsx
+++ b/frontend/src/pages/casedesigner/detail/BookcaseDetail.tsx
@@ -55,7 +55,7 @@ export default function BookcaseDetail() {
   const navigate = useNavigate();
   // -------- STATE --------
   // From URL
-  const { id } = useParams();
+  let { id } = useParams();
   const isAddPage = id === undefined;
   const [isModifiable, setIsModifiable] = useState<boolean>(id === undefined);
 
@@ -74,7 +74,7 @@ export default function BookcaseDetail() {
   // Load the Bookcase data on page load
   useEffect(() => {
     if (!isAddPage) {
-      CASE_DESIGNER_API.getBookcaseDetail(id)
+      CASE_DESIGNER_API.getBookcaseDetail(id!)
         .then((response) => {
           const bookcase = APIToInternalBookcaseConversion(response);
           setOriginalData(bookcase);
@@ -108,6 +108,7 @@ export default function BookcaseDetail() {
           draft.name = bookcaseNameInSaveAsPopup;
         });
         setOriginalData(APIToInternalBookcaseConversion(response));
+        id = response.id!.toString();
         navigate("/bookcases/detail/" + response.id);
       })
       .catch((error) => {
@@ -124,6 +125,7 @@ export default function BookcaseDetail() {
 
   const callModifyBookcaseAPI = () => {
     const APIbookcase = InternalToAPIBookcaseConversion(bookcase);
+    APIbookcase.id = Number(id);
     CASE_DESIGNER_API.modifyBookcase(APIbookcase)
       .then(() => {
         showSuccess(toast, "Bookcase modified successfully");


### PR DESCRIPTION
## Feature Description/Implementation
- When pressing save as the first time, a new bookcase was created but the stored ID was stale
- This meant that when pressing save, the old id was used, but the new name was used, resulting in an error because a bookcase already existed

## Dependencies

## Everything Else
