### PR TITLE
Prevent user from entering book dimensions of 0

### DIFF
--- a/frontend/src/components/text/TextWrapperNullableNumberEditor.tsx
+++ b/frontend/src/components/text/TextWrapperNullableNumberEditor.tsx
@@ -7,6 +7,7 @@ interface TextWrapperNullableNumberEditorProps {
   onValueChange: (newValue: number | undefined) => void;
   valueClassName?: string;
   defaultValue: number | undefined;
+  min?: number;
 }
 
 export function TextWrapperNullableNumberEditor(
@@ -25,7 +26,8 @@ export function TextWrapperNullableNumberEditor(
             (newValue: number | undefined) =>
               props.onValueChange(newValue ?? props.defaultValue),
             "w-4",
-            props.disabled
+            props.disabled,
+            props.min
           )}
         </div>
       )}

--- a/frontend/src/pages/books/BookAdd.tsx
+++ b/frontend/src/pages/books/BookAdd.tsx
@@ -175,7 +175,9 @@ export default function BookAdd() {
               book.width = newValue;
             });
           },
-          "decimalNumberBookAdd"
+          "decimalNumberBookAdd",
+          false,
+          0.01
         ),
     },
     {
@@ -191,7 +193,9 @@ export default function BookAdd() {
               book.height = newValue;
             });
           },
-          "decimalNumberBookAdd"
+          "decimalNumberBookAdd",
+          false,
+          0.01
         ),
     },
     {
@@ -207,7 +211,9 @@ export default function BookAdd() {
               book.thickness = newValue;
             });
           },
-          "decimalNumberBookAdd"
+          "decimalNumberBookAdd",
+          false,
+          0.01
         ),
     },
     {

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -644,6 +644,7 @@ export default function BookDetail() {
                 onValueChange={(newValue) => setHeight(newValue ?? undefined)}
                 defaultValue={undefined}
                 valueClassName="flex 2rem"
+                min={0.01}
               />
             </div>
             <div className="flex p-0 col-4">
@@ -655,6 +656,7 @@ export default function BookDetail() {
                 onValueChange={(newValue) => setWidth(newValue ?? undefined)}
                 defaultValue={undefined}
                 valueClassName="flex 2rem"
+                min={0.01}
               />
             </div>
             <div className="flex p-0 col-4">
@@ -668,6 +670,7 @@ export default function BookDetail() {
                 }
                 defaultValue={undefined}
                 valueClassName="flex 2rem"
+                min={0.01}
               />
             </div>
           </div>


### PR DESCRIPTION
## Feature Description/Implementation

The field can be left blank, which will use the default. However, entering 0 will force the editor to go to 0.01

## Dependencies

## Everything Else
