### PR TITLE
Improve Related Books Algo

### DIFF
--- a/backend/books/isbn.py
+++ b/backend/books/isbn.py
@@ -5,7 +5,7 @@ from dateutil import parser
 import PIL.Image as Image
 
 import threading
-from books.related_books import standardize_title, get_related_isbns
+from books.related_books import standardize_title, get_related_isbns, get_related_books_data
 
 from books.models import Book, RelatedBookGroup
 from books.serializers import RelatedBookSerializer
@@ -145,18 +145,8 @@ class ISBNTools:
     def check_for_related_book_group(self, data):
         # If this book has related books, then add related books
         try:
-            # related_book_group = RelatedBookGroup.objects.get(title=standardize_title(data['title']))
-            # data['related_books'] = RelatedBookSerializer(related_book_group.related_books.all(), many=True).data
-            related_book_isbns_list = get_related_isbns(data['isbn_13'])
-            print(related_book_isbns_list)
-            data['related_books'] = RelatedBookSerializer(
-                Book.objects.filter(related_book_group__in=Book.objects.filter(Q(isbn_13__in=related_book_isbns_list) | Q(isbn_10__in=related_book_isbns_list)).values('related_book_group')),
-                many=True).data
+            data['related_books'] = get_related_books_data(data['isbn_13'])
             data['num_related_books'] = len(data['related_books'])
-            # related_book_group = related_books[0].related_book_group
-            # print(related_books.annotate(related_books_list='related_book_group__related_books'))
-            # data['related_books'] = RelatedBookSerializer(related_book_group.related_books.all(), many=True).data
-            # data['num_related_books'] = len(Book.objects.filter(related_book_group=related_book_group))
         except RelatedBookGroup.DoesNotExist:
             data['related_books'] = []
             data['num_related_books'] = 0

--- a/backend/books/isbn.py
+++ b/backend/books/isbn.py
@@ -5,10 +5,12 @@ from dateutil import parser
 import PIL.Image as Image
 
 import threading
-from books.related_books import standardize_title
+from books.related_books import standardize_title, get_related_isbns
 
 from books.models import Book, RelatedBookGroup
 from books.serializers import RelatedBookSerializer
+
+from django.db.models import Q
 
 
 class ISBNTools:
@@ -143,9 +145,18 @@ class ISBNTools:
     def check_for_related_book_group(self, data):
         # If this book has related books, then add related books
         try:
-            related_book_group = RelatedBookGroup.objects.get(title=standardize_title(data['title']))
-            data['related_books'] = RelatedBookSerializer(related_book_group.related_books.all(), many=True).data
-            data['num_related_books'] = len(Book.objects.filter(related_book_group=related_book_group))
+            # related_book_group = RelatedBookGroup.objects.get(title=standardize_title(data['title']))
+            # data['related_books'] = RelatedBookSerializer(related_book_group.related_books.all(), many=True).data
+            related_book_isbns_list = get_related_isbns(data['isbn_13'])
+            print(related_book_isbns_list)
+            data['related_books'] = RelatedBookSerializer(
+                Book.objects.filter(related_book_group__in=Book.objects.filter(Q(isbn_13__in=related_book_isbns_list) | Q(isbn_10__in=related_book_isbns_list)).values('related_book_group')),
+                many=True).data
+            data['num_related_books'] = len(data['related_books'])
+            # related_book_group = related_books[0].related_book_group
+            # print(related_books.annotate(related_books_list='related_book_group__related_books'))
+            # data['related_books'] = RelatedBookSerializer(related_book_group.related_books.all(), many=True).data
+            # data['num_related_books'] = len(Book.objects.filter(related_book_group=related_book_group))
         except RelatedBookGroup.DoesNotExist:
             data['related_books'] = []
             data['num_related_books'] = 0

--- a/backend/books/related_books.py
+++ b/backend/books/related_books.py
@@ -1,5 +1,21 @@
 import re
+from urllib.request import urlopen
+import json, os, io, environ, urllib
+from typing import List
+from lxml import etree
+from isbnlib import *
 
 
 def standardize_title(title: str) -> str:
     return re.sub(r'[^a-zA-Z0-9]', '', title).lower()
+
+
+def get_related_isbns(isbn: str) -> List[str]:
+    related_books_endpoint = f"https://www.librarything.com/api/thingISBN/{isbn}"
+    resp = urlopen(related_books_endpoint)
+    tree = etree.parse(source=resp)
+    return {parse_isbn(xml_isbn.text) for xml_isbn in tree.getroot()}
+
+
+def parse_isbn(isbn: str) -> str:
+    return canonical(to_isbn13(isbn)) if is_isbn10(isbn) else canonical(isbn)

--- a/backend/books/related_books.py
+++ b/backend/books/related_books.py
@@ -1,9 +1,13 @@
 import re
 from urllib.request import urlopen
-import json, os, io, environ, urllib
-from typing import List
+from typing import List, Dict
 from lxml import etree
 from isbnlib import *
+from books.models import Book
+
+from books.serializers import RelatedBookSerializer
+from django.db.models import Q
+from books.models import RelatedBookGroup
 
 
 def standardize_title(title: str) -> str:
@@ -14,8 +18,34 @@ def get_related_isbns(isbn: str) -> List[str]:
     related_books_endpoint = f"https://www.librarything.com/api/thingISBN/{isbn}"
     resp = urlopen(related_books_endpoint)
     tree = etree.parse(source=resp)
-    return {parse_isbn(xml_isbn.text) for xml_isbn in tree.getroot()}
+    related_isbns = {parse_isbn(xml_isbn.text) for xml_isbn in tree.getroot()}
+    related_isbns.discard(isbn)  # Remove self from related isbns
+    return related_isbns
 
 
 def parse_isbn(isbn: str) -> str:
     return canonical(to_isbn13(isbn)) if is_isbn10(isbn) else canonical(isbn)
+
+
+def _get_related_book_data(related_book_isbns: List[str]) -> List[Dict]:
+    return RelatedBookSerializer(Book.objects.filter(related_book_group__in=Book.objects.filter(Q(isbn_13__in=related_book_isbns) | Q(isbn_10__in=related_book_isbns)).values('related_book_group')),
+                                 many=True).data
+
+
+def get_related_books_data(isbn: str) -> List[Dict]:
+    return _get_related_book_data(get_related_isbns(isbn))
+
+
+def combine_related_books_groups(related_book_group_ids: List[int]):
+    related_books = Book.objects.filter(related_book_group__in=related_book_group_ids)  # Get all books that are in any related book groups
+    # for sake of expected outcomes, let's use the related book group with the lowest id
+    combined_related_book_group_id = min(related_book_group_ids)
+    related_books.update(related_book_group=combined_related_book_group_id)
+    related_book_ids_to_delete = related_book_group_ids.copy()
+    related_book_ids_to_delete.remove(combined_related_book_group_id)
+    _delete_related_books_groups(related_book_ids_to_delete)
+    return combined_related_book_group_id
+
+
+def _delete_related_books_groups(related_book_group_ids: List[int]):
+    RelatedBookGroup.objects.filter(id__in=related_book_group_ids).delete()

--- a/backend/books/views.py
+++ b/backend/books/views.py
@@ -15,6 +15,7 @@ from purchase_orders.models import Purchase
 from sales.models import Sale
 from helpers.csv_writer import CSVWriter
 from utils.permissions import CustomBasePermission
+from .related_books import get_related_isbns
 
 from .serializers import BookListAddSerializer, BookSerializer, ISBNSerializer, BookImageSerializer, BookInventoryCorrectionSerializer, RelatedBookSerializer
 from .isbn import ISBNTools
@@ -24,7 +25,7 @@ from .search_filters import *
 from .utils import str2bool
 from .book_images import BookImageCreator
 from .exceptions import *
-from .related_books import standardize_title
+from .related_books import standardize_title, combine_related_books_groups
 
 
 class ISBNSearchView(APIView):
@@ -197,8 +198,20 @@ class ListCreateBookAPIView(ListCreateAPIView, BookImageCreator):
         return Response(res, status=status.HTTP_201_CREATED, headers=headers)
 
     def get_or_create_related_books_group(self, data):
-        obj, created = RelatedBookGroup.objects.get_or_create(title=standardize_title(data['title']))
-        data['related_book_group'] = obj.pk
+        related_books_list = get_related_isbns(data['isbn_13'])
+        related_books_in_db = Book.objects.filter(isbn_13__in=related_books_list)
+        related_book_group_ids = {related_book_group_obj['related_book_group'] for related_book_group_obj in related_books_in_db.values('related_book_group')}
+        if len(related_book_group_ids) == 0:  # No existing related books for this new book, so create new group
+            print("No pre-existing relations")
+            related_book_group_id = RelatedBookGroup.objects.create(title=standardize_title(data['title'])).id
+        elif len(related_book_group_ids) == 1:  # One unified related books group for this book, so add this book to the group
+            print("one group related")
+            (related_book_group_id,) = related_book_group_ids
+        else:  # multiple related book groups, so must combine them first
+            print("multiple related groups")
+            related_book_group_id = combine_related_books_groups(related_book_group_ids)
+        # obj, created = RelatedBookGroup.objects.get_or_create(id=)
+        data['related_book_group'] = related_book_group_id
         return data
 
     def convert_zero_to_null(self, data):


### PR DESCRIPTION
## Feature Description/Implementation
- Change related books algorithm to use an external API for relating books.
- Related book groups in database have title just for making things slightly easier to understand what a related book group has when reading the database. The name itself shouldn't for the related book group should not actually be used in any logic anymore.
## Dependencies

## Everything Else
