### PR TITLE
Remote books frontend integration

### DIFF
--- a/frontend/src/apis/books/BooksAPI.tsx
+++ b/frontend/src/apis/books/BooksAPI.tsx
@@ -47,6 +47,7 @@ export interface APIBook {
   isGhost?: boolean;
   num_related_books?: number;
   related_books?: APIRelatedBook[];
+  remote_book?: APIRemoteBook;
 }
 
 export interface APIRelatedBook {
@@ -137,6 +138,22 @@ export interface InvnCorrResp {
   adjustment: number;
   username: string;
   date: string;
+}
+
+export interface APIRemoteBook {
+  title: string;
+  authors: string[];
+  isbn13: string;
+  isbn10: string;
+  publisher: string;
+  publicationYear: number;
+  pageCount?: number;
+  height?: number;
+  width?: number;
+  thickness?: number;
+  retailPrice: number;
+  inventoryCount: number;
+  imageUrl?: string;
 }
 
 export const BOOKS_API = {

--- a/frontend/src/apis/books/BooksConversions.tsx
+++ b/frontend/src/apis/books/BooksConversions.tsx
@@ -190,6 +190,10 @@ export function APIToInternalRemoteBookConversion(
     thickness: book.thickness,
     retailPrice: book.retailPrice,
     stock: book.inventoryCount,
-    thumbnailURL: book.imageUrl,
+    // Temporary workaround because subsidiary gives http instead of https
+    thumbnailURL:
+      book.imageUrl?.substring(0, 4) === "http"
+        ? book.imageUrl.slice(0, 4) + "s" + book.imageUrl.slice(4)
+        : book.imageUrl,
   };
 }

--- a/frontend/src/apis/books/BooksConversions.tsx
+++ b/frontend/src/apis/books/BooksConversions.tsx
@@ -192,7 +192,7 @@ export function APIToInternalRemoteBookConversion(
     stock: book.inventoryCount,
     // Temporary workaround because subsidiary gives http instead of https
     thumbnailURL:
-      book.imageUrl?.substring(0, 4) === "http"
+      book.imageUrl?.substring(0, 5) === "http:"
         ? book.imageUrl.slice(0, 4) + "s" + book.imageUrl.slice(4)
         : book.imageUrl,
   };

--- a/frontend/src/apis/books/BooksConversions.tsx
+++ b/frontend/src/apis/books/BooksConversions.tsx
@@ -190,7 +190,7 @@ export function APIToInternalRemoteBookConversion(
     thickness: book.thickness,
     retailPrice: book.retailPrice,
     stock: book.inventoryCount,
-    // Temporary workaround because subsidiary gives http instead of https
+    // Converts http: to https: if necessary
     thumbnailURL:
       book.imageUrl?.substring(0, 5) === "http:"
         ? book.imageUrl.slice(0, 4) + "s" + book.imageUrl.slice(4)

--- a/frontend/src/apis/books/BooksConversions.tsx
+++ b/frontend/src/apis/books/BooksConversions.tsx
@@ -1,6 +1,6 @@
 import { v4 as uuid } from "uuid";
 import { BookWithDBTag } from "../../pages/books/BookAdd";
-import { Book } from "../../pages/books/BookList";
+import { Book, RemoteBook } from "../../pages/books/BookList";
 import { externalToInternalDate } from "../../util/DateOps";
 import {
   ArrayToCommaSeparatedString,
@@ -12,6 +12,7 @@ import {
   APIBookWithDBTag,
   APILineItemType,
   APIRelatedBook,
+  APIRemoteBook,
 } from "./BooksAPI";
 import {
   BookDetailLineItem,
@@ -108,6 +109,9 @@ export function APIToInternalBookConversion(book: APIBook): Book {
     relatedBooks: book.related_books?.map((relatedBook) => {
       return APIToInternalRelatedBookConversion(relatedBook);
     }),
+    remoteBook: book.remote_book
+      ? APIToInternalRemoteBookConversion(book.remote_book)
+      : undefined,
   };
 }
 
@@ -164,5 +168,28 @@ export function APIToInternalBookConversionWithDB(
     relatedBooks: book.related_books?.map((relatedBook) => {
       return APIToInternalRelatedBookConversion(relatedBook);
     }),
+    remoteBook: book.remote_book
+      ? APIToInternalRemoteBookConversion(book.remote_book)
+      : undefined,
+  };
+}
+
+export function APIToInternalRemoteBookConversion(
+  book: APIRemoteBook
+): RemoteBook {
+  return {
+    title: book.title,
+    authors: ArrayToCommaSeparatedString(book.authors),
+    isbn13: book.isbn13,
+    isbn10: book.isbn10,
+    publisher: book.publisher,
+    publishedYear: book.publicationYear,
+    pageCount: book.pageCount,
+    width: book.width,
+    height: book.height,
+    thickness: book.thickness,
+    retailPrice: book.retailPrice,
+    stock: book.inventoryCount,
+    thumbnailURL: book.imageUrl,
   };
 }

--- a/frontend/src/components/buttons/ImportFieldButton.tsx
+++ b/frontend/src/components/buttons/ImportFieldButton.tsx
@@ -1,0 +1,19 @@
+import { Button } from "primereact/button";
+
+export interface ImportFieldButtonProps {
+  onClick: () => void;
+  isVisible: boolean;
+}
+
+export default function ImportFieldButton(props: ImportFieldButtonProps) {
+  return (
+    <Button
+      className="ml-2"
+      icon="pi pi-fw pi-upload"
+      style={{ height: 20, width: 25 }}
+      onClick={props.onClick}
+      visible={props.isVisible}
+      type="button"
+    />
+  );
+}

--- a/frontend/src/components/buttons/ImportFieldButton.tsx
+++ b/frontend/src/components/buttons/ImportFieldButton.tsx
@@ -1,17 +1,21 @@
 import { Button } from "primereact/button";
+import { CSSProperties } from "react";
+import "../../css/TableCell.css";
 
 export interface ImportFieldButtonProps {
   onClick: () => void;
   isVisible: boolean;
   isDisabled: boolean;
+  style?: CSSProperties;
+  className?: string;
 }
 
 export default function ImportFieldButton(props: ImportFieldButtonProps) {
   return (
     <Button
-      className="ml-2"
+      className={props.className}
       icon="pi pi-fw pi-file-import"
-      style={{ height: 20, width: 25 }}
+      style={props.style ?? { height: 20, width: 25 }}
       onClick={props.onClick}
       visible={props.isVisible}
       type="button"

--- a/frontend/src/components/buttons/ImportFieldButton.tsx
+++ b/frontend/src/components/buttons/ImportFieldButton.tsx
@@ -1,4 +1,5 @@
 import { Button } from "primereact/button";
+import { TooltipOptions } from "primereact/tooltip/tooltipoptions";
 import { CSSProperties } from "react";
 import "../../css/TableCell.css";
 
@@ -8,18 +9,22 @@ export interface ImportFieldButtonProps {
   isDisabled: boolean;
   style?: CSSProperties;
   className?: string;
+  tooltip?: string;
+  tooltipOptions?: TooltipOptions;
 }
 
 export default function ImportFieldButton(props: ImportFieldButtonProps) {
   return (
     <Button
-      className={props.className}
       icon="pi pi-fw pi-file-import"
+      type="button"
+      className={props.className}
       style={props.style ?? { height: 20, width: 25 }}
       onClick={props.onClick}
       visible={props.isVisible}
-      type="button"
       disabled={props.isDisabled}
+      tooltip={props.tooltip}
+      tooltipOptions={props.tooltipOptions}
     />
   );
 }

--- a/frontend/src/components/buttons/ImportFieldButton.tsx
+++ b/frontend/src/components/buttons/ImportFieldButton.tsx
@@ -3,17 +3,19 @@ import { Button } from "primereact/button";
 export interface ImportFieldButtonProps {
   onClick: () => void;
   isVisible: boolean;
+  isDisabled: boolean;
 }
 
 export default function ImportFieldButton(props: ImportFieldButtonProps) {
   return (
     <Button
       className="ml-2"
-      icon="pi pi-fw pi-upload"
+      icon="pi pi-fw pi-file-import"
       style={{ height: 20, width: 25 }}
       onClick={props.onClick}
       visible={props.isVisible}
       type="button"
+      disabled={props.isDisabled}
     />
   );
 }

--- a/frontend/src/components/datatable/DeleteColumn.tsx
+++ b/frontend/src/components/datatable/DeleteColumn.tsx
@@ -8,7 +8,6 @@ interface DeleteColumnProps<T> {
   hidden?: boolean;
   style?: CSSProperties;
   buttonStyle?: CSSProperties;
-  hideHeader?: boolean;
 }
 
 export default function DeleteColumn<T>(props: DeleteColumnProps<T>) {
@@ -22,7 +21,7 @@ export default function DeleteColumn<T>(props: DeleteColumnProps<T>) {
   return (
     <Column
       body={rowDeleteButton}
-      header={props.hideHeader ? "" : "Delete"}
+      header={"Delete"}
       exportable={false}
       style={props.style ?? { width: "2rem" }}
       hidden={props.hidden}

--- a/frontend/src/components/datatable/DeleteColumn.tsx
+++ b/frontend/src/components/datatable/DeleteColumn.tsx
@@ -8,6 +8,7 @@ interface DeleteColumnProps<T> {
   hidden?: boolean;
   style?: CSSProperties;
   buttonStyle?: CSSProperties;
+  hideHeader?: boolean;
 }
 
 export default function DeleteColumn<T>(props: DeleteColumnProps<T>) {
@@ -21,7 +22,7 @@ export default function DeleteColumn<T>(props: DeleteColumnProps<T>) {
   return (
     <Column
       body={rowDeleteButton}
-      header={"Delete"}
+      header={props.hideHeader ? "" : "Delete"}
       exportable={false}
       style={props.style ?? { width: "2rem" }}
       hidden={props.hidden}

--- a/frontend/src/components/templates/ImageTemplate.tsx
+++ b/frontend/src/components/templates/ImageTemplate.tsx
@@ -27,6 +27,7 @@ export function ImageTemplate(imageURL: string) {
 }
 
 export default function ImageTemplateWithButtons(
+  importButton: JSX.Element,
   deleteButton: JSX.Element,
   uploadButton: JSX.Element,
   thumbnailURL: string
@@ -53,6 +54,7 @@ export default function ImageTemplateWithButtons(
         />
       </div>
       <div className="flex justify-content-between">
+        {importButton}
         {uploadButton}
         {deleteButton}
       </div>

--- a/frontend/src/components/text/TextWrapperNullableNumberEditor.tsx
+++ b/frontend/src/components/text/TextWrapperNullableNumberEditor.tsx
@@ -1,4 +1,5 @@
 import { NullableNumberEditor } from "../editors/NumberEditor";
+import "../../css/TableCell.css";
 
 interface TextWrapperNullableNumberEditorProps {
   disabled: boolean;
@@ -25,7 +26,7 @@ export function TextWrapperNullableNumberEditor(
             props.value,
             (newValue: number | undefined) =>
               props.onValueChange(newValue ?? props.defaultValue),
-            "w-4",
+            "w-4 editorBookDetail",
             props.disabled,
             props.min
           )}

--- a/frontend/src/components/text/TextWrapperNullableNumberEditor.tsx
+++ b/frontend/src/components/text/TextWrapperNullableNumberEditor.tsx
@@ -22,14 +22,16 @@ export function TextWrapperNullableNumberEditor(
         </p>
       ) : (
         <div className={props.valueClassName ?? ""}>
-          {NullableNumberEditor(
-            props.value,
-            (newValue: number | undefined) =>
-              props.onValueChange(newValue ?? props.defaultValue),
-            "w-4 editorBookDetail",
-            props.disabled,
-            props.min
-          )}
+          <p className="vertical-align-middle">
+            {NullableNumberEditor(
+              props.value,
+              (newValue: number | undefined) =>
+                props.onValueChange(newValue ?? props.defaultValue),
+              "w-4 editorBookDetail",
+              props.disabled,
+              props.min
+            )}
+          </p>
         </div>
       )}
     </>

--- a/frontend/src/css/TableCell.css
+++ b/frontend/src/css/TableCell.css
@@ -32,6 +32,10 @@
     width: 80px;
 }
 
+.addPageImportIcon .pi {
+    font-size: 0.8rem;
+}
+
 /* BB PO SR detail */
 .integernumberPODetail .p-inputtext {
     width: 100px;

--- a/frontend/src/css/TableCell.css
+++ b/frontend/src/css/TableCell.css
@@ -26,6 +26,12 @@
     height: 10;
 }
 
+/* Book Detail */
+.editorBookDetail .p-inputtext {
+    padding: 0.15rem 0.15rem;
+    width: 80px;
+}
+
 /* BB PO SR detail */
 .integernumberPODetail .p-inputtext {
     width: 100px;

--- a/frontend/src/pages/books/BookAdd.tsx
+++ b/frontend/src/pages/books/BookAdd.tsx
@@ -416,14 +416,18 @@ export default function BookAdd() {
     return (
       <>
         <Tooltip target=".custom-bookadd-tooltip" showDelay={100} />
-        <ImageUploader
-          uploadHandler={(e: FileUploadHandlerEvent) =>
-            onImageChange(e, rowData.id)
-          }
-          className="addPageImportIcon"
-          style={{ height: 20, width: 20, paddingLeft: 3, paddingRight: 3 }}
+        <div
+          className="custom-bookadd-tooltip"
           data-pr-tooltip={"Upload Custom Image"}
-        />
+        >
+          <ImageUploader
+            uploadHandler={(e: FileUploadHandlerEvent) =>
+              onImageChange(e, rowData.id)
+            }
+            className="addPageImportIcon"
+            style={{ height: 20, width: 20, paddingLeft: 3, paddingRight: 3 }}
+          />
+        </div>
       </>
     );
   };

--- a/frontend/src/pages/books/BookAdd.tsx
+++ b/frontend/src/pages/books/BookAdd.tsx
@@ -153,181 +153,25 @@ export default function BookAdd() {
       field: "pageCount",
       header: "Page Count",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) => (
-        <>
-          <div>
-            {NullableIntegerEditor(
-              rowData.pageCount,
-              (newValue) => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.pageCount = newValue;
-                });
-              },
-              "integerNumbeBookAdd"
-            )}
-          </div>
-          <div>
-            <label style={{ fontSize: "0.7rem" }}>
-              {rowData.remoteBook &&
-              rowData.remoteBook.pageCount != rowData.pageCount
-                ? `(R: ${rowData.remoteBook.pageCount})`
-                : ""}
-            </label>
-            <ImportFieldButton
-              onClick={() => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.pageCount = book.remoteBook!.pageCount;
-                });
-              }}
-              isDisabled={
-                rowData.remoteBook?.pageCount == rowData.pageCount ||
-                !rowData.remoteBook?.pageCount
-              }
-              isVisible={rowData.remoteBook?.pageCount != null}
-              className="mt-1 ml-1 addPageImportIcon"
-              style={{ height: 20, width: 20 }}
-            />
-          </div>
-        </>
-      ),
+      customBody: (rowData: BookWithDBTag) => pageCountBody(rowData),
     },
     {
       field: "width",
       header: "Width",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) => (
-        <>
-          <div>
-            {NullableNumberEditor(
-              rowData.width,
-              (newValue) => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.width = newValue;
-                });
-              },
-              "decimalNumberBookAdd",
-              false,
-              0.01
-            )}
-          </div>
-          <div>
-            <label style={{ fontSize: "0.7rem" }}>
-              {rowData.remoteBook && rowData.remoteBook.width != rowData.width
-                ? `(R: ${rowData.remoteBook.width})`
-                : ""}
-            </label>
-            <ImportFieldButton
-              onClick={() => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.width = book.remoteBook!.width;
-                });
-              }}
-              isDisabled={
-                rowData.remoteBook?.width == rowData.width ||
-                !rowData.remoteBook?.width
-              }
-              isVisible={rowData.remoteBook?.width != null}
-              className="mt-1 ml-1 addPageImportIcon"
-              style={{ height: 20, width: 20 }}
-            />
-          </div>
-        </>
-      ),
+      customBody: (rowData: BookWithDBTag) => widthBody(rowData),
     },
     {
       field: "height",
       header: "Height",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) => (
-        <>
-          <div>
-            {NullableNumberEditor(
-              rowData.height,
-              (newValue) => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.height = newValue;
-                });
-              },
-              "decimalNumberBookAdd",
-              false,
-              0.01
-            )}
-          </div>
-          <div>
-            <label style={{ fontSize: "0.7rem" }}>
-              {rowData.remoteBook && rowData.remoteBook.height != rowData.height
-                ? `(R: ${rowData.remoteBook.height})`
-                : ""}
-            </label>
-            <ImportFieldButton
-              onClick={() => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.height = book.remoteBook!.height;
-                });
-              }}
-              isDisabled={
-                rowData.remoteBook?.height == rowData.height ||
-                !rowData.remoteBook?.height
-              }
-              isVisible={rowData.remoteBook?.height != null}
-              className="mt-1 ml-1 addPageImportIcon"
-              style={{ height: 20, width: 20 }}
-            />
-          </div>
-        </>
-      ),
+      customBody: (rowData: BookWithDBTag) => heightBody(rowData),
     },
     {
       field: "thickness",
       header: "Thickness",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) => (
-        <>
-          <div>
-            {NullableNumberEditor(
-              rowData.thickness,
-              (newValue) => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.thickness = newValue;
-                });
-              },
-              "decimalNumberBookAdd",
-              false,
-              0.01
-            )}
-          </div>
-          <div>
-            <label style={{ fontSize: "0.7rem" }}>
-              {rowData.remoteBook &&
-              rowData.remoteBook.thickness != rowData.thickness
-                ? `(R: ${rowData.remoteBook.thickness})`
-                : ""}
-            </label>
-            <ImportFieldButton
-              onClick={() => {
-                setBooks((draft) => {
-                  const book = findById(draft, rowData.id)!;
-                  book.thickness = book.remoteBook!.thickness;
-                });
-              }}
-              isDisabled={
-                rowData.remoteBook?.thickness == rowData.thickness ||
-                !rowData.remoteBook?.thickness
-              }
-              isVisible={rowData.remoteBook?.thickness != null}
-              className="mt-1 ml-1 addPageImportIcon"
-              style={{ height: 20, width: 20 }}
-            />
-          </div>
-        </>
-      ),
+      customBody: (rowData: BookWithDBTag) => thicknessBody(rowData),
     },
     {
       field: "retailPrice",
@@ -351,6 +195,178 @@ export default function BookAdd() {
       style: { width: "4%", fontSize: "small" },
     },
   ];
+
+  const pageCountBody = (rowData: BookWithDBTag) => {
+    return (
+      <>
+        <div>
+          {NullableIntegerEditor(
+            rowData.pageCount,
+            (newValue) => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.pageCount = newValue;
+              });
+            },
+            "integerNumbeBookAdd"
+          )}
+        </div>
+        <div>
+          <label style={{ fontSize: "0.7rem" }}>
+            {rowData.remoteBook &&
+            rowData.remoteBook.pageCount != rowData.pageCount
+              ? `(R: ${rowData.remoteBook.pageCount})`
+              : ""}
+          </label>
+          <ImportFieldButton
+            onClick={() => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.pageCount = book.remoteBook!.pageCount;
+              });
+            }}
+            isDisabled={
+              rowData.remoteBook?.pageCount == rowData.pageCount ||
+              !rowData.remoteBook?.pageCount
+            }
+            isVisible={rowData.remoteBook?.pageCount != null}
+            className="mt-1 ml-1 addPageImportIcon"
+            style={{ height: 20, width: 20 }}
+          />
+        </div>
+      </>
+    );
+  };
+
+  const widthBody = (rowData: BookWithDBTag) => {
+    return (
+      <>
+        <div>
+          {NullableNumberEditor(
+            rowData.width,
+            (newValue) => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.width = newValue;
+              });
+            },
+            "decimalNumberBookAdd",
+            false,
+            0.01
+          )}
+        </div>
+        <div>
+          <label style={{ fontSize: "0.7rem" }}>
+            {rowData.remoteBook && rowData.remoteBook.width != rowData.width
+              ? `(R: ${rowData.remoteBook.width})`
+              : ""}
+          </label>
+          <ImportFieldButton
+            onClick={() => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.width = book.remoteBook!.width;
+              });
+            }}
+            isDisabled={
+              rowData.remoteBook?.width == rowData.width ||
+              !rowData.remoteBook?.width
+            }
+            isVisible={rowData.remoteBook?.width != null}
+            className="mt-1 ml-1 addPageImportIcon"
+            style={{ height: 20, width: 20 }}
+          />
+        </div>
+      </>
+    );
+  };
+
+  const heightBody = (rowData: BookWithDBTag) => {
+    return (
+      <>
+        <div>
+          {NullableNumberEditor(
+            rowData.height,
+            (newValue) => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.height = newValue;
+              });
+            },
+            "decimalNumberBookAdd",
+            false,
+            0.01
+          )}
+        </div>
+        <div>
+          <label style={{ fontSize: "0.7rem" }}>
+            {rowData.remoteBook && rowData.remoteBook.height != rowData.height
+              ? `(R: ${rowData.remoteBook.height})`
+              : ""}
+          </label>
+          <ImportFieldButton
+            onClick={() => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.height = book.remoteBook!.height;
+              });
+            }}
+            isDisabled={
+              rowData.remoteBook?.height == rowData.height ||
+              !rowData.remoteBook?.height
+            }
+            isVisible={rowData.remoteBook?.height != null}
+            className="mt-1 ml-1 addPageImportIcon"
+            style={{ height: 20, width: 20 }}
+          />
+        </div>
+      </>
+    );
+  };
+
+  const thicknessBody = (rowData: BookWithDBTag) => {
+    return (
+      <>
+        <div>
+          {NullableNumberEditor(
+            rowData.thickness,
+            (newValue) => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.thickness = newValue;
+              });
+            },
+            "decimalNumberBookAdd",
+            false,
+            0.01
+          )}
+        </div>
+        <div>
+          <label style={{ fontSize: "0.7rem" }}>
+            {rowData.remoteBook &&
+            rowData.remoteBook.thickness != rowData.thickness
+              ? `(R: ${rowData.remoteBook.thickness})`
+              : ""}
+          </label>
+          <ImportFieldButton
+            onClick={() => {
+              setBooks((draft) => {
+                const book = findById(draft, rowData.id)!;
+                book.thickness = book.remoteBook!.thickness;
+              });
+            }}
+            isDisabled={
+              rowData.remoteBook?.thickness == rowData.thickness ||
+              !rowData.remoteBook?.thickness
+            }
+            isVisible={rowData.remoteBook?.thickness != null}
+            className="mt-1 ml-1 addPageImportIcon"
+            style={{ height: 20, width: 20 }}
+          />
+        </div>
+      </>
+    );
+  };
 
   // Image event handlers
 
@@ -404,6 +420,7 @@ export default function BookAdd() {
           const newBook = findById(draft, book.id)!;
           newBook.newImageData = newImageData;
           newBook.thumbnailURL = URL.createObjectURL(file);
+          showSuccess(toast, "Image imported successfully");
         });
       })
       .catch(() => {
@@ -580,7 +597,6 @@ export default function BookAdd() {
     },
     style: { width: "2%", fontSize: 12 },
     buttonStyle: { width: 30, height: 30 },
-    hideHeader: true,
   });
 
   const columns = createColumns(COLUMNS);

--- a/frontend/src/pages/books/BookAdd.tsx
+++ b/frontend/src/pages/books/BookAdd.tsx
@@ -41,6 +41,7 @@ import { Column } from "primereact/column";
 import BookDetailRelatedBooks from "./BookDetailRelatedBooks";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
+import ImportFieldButton from "../../components/buttons/ImportFieldButton";
 
 export interface BookWithDBTag extends Book {
   fromDB: boolean;
@@ -150,71 +151,181 @@ export default function BookAdd() {
       field: "pageCount",
       header: "Page Count",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) =>
-        NullableIntegerEditor(
-          rowData.pageCount,
-          (newValue) => {
-            setBooks((draft) => {
-              const book = findById(draft, rowData.id)!;
-              book.pageCount = newValue;
-            });
-          },
-          "integerNumbeBookAdd"
-        ),
+      customBody: (rowData: BookWithDBTag) => (
+        <>
+          <div>
+            {NullableIntegerEditor(
+              rowData.pageCount,
+              (newValue) => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.pageCount = newValue;
+                });
+              },
+              "integerNumbeBookAdd"
+            )}
+          </div>
+          <div>
+            <label style={{ fontSize: "0.7rem" }}>
+              {rowData.remoteBook &&
+              rowData.remoteBook.pageCount != rowData.pageCount
+                ? `(R: ${rowData.remoteBook.pageCount})`
+                : ""}
+            </label>
+            <ImportFieldButton
+              onClick={() => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.pageCount = book.remoteBook!.pageCount;
+                });
+              }}
+              isDisabled={
+                rowData.remoteBook?.pageCount == rowData.pageCount ||
+                !rowData.remoteBook?.pageCount
+              }
+              isVisible={rowData.remoteBook?.pageCount != null}
+              className="mt-1 ml-1 addPageImportIcon"
+              style={{ height: 20, width: 20 }}
+            />
+          </div>
+        </>
+      ),
     },
     {
       field: "width",
       header: "Width",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) =>
-        NullableNumberEditor(
-          rowData.width,
-          (newValue) => {
-            setBooks((draft) => {
-              const book = findById(draft, rowData.id)!;
-              book.width = newValue;
-            });
-          },
-          "decimalNumberBookAdd",
-          false,
-          0.01
-        ),
+      customBody: (rowData: BookWithDBTag) => (
+        <>
+          <div>
+            {NullableNumberEditor(
+              rowData.width,
+              (newValue) => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.width = newValue;
+                });
+              },
+              "decimalNumberBookAdd",
+              false,
+              0.01
+            )}
+          </div>
+          <div>
+            <label style={{ fontSize: "0.7rem" }}>
+              {rowData.remoteBook && rowData.remoteBook.width != rowData.width
+                ? `(R: ${rowData.remoteBook.width})`
+                : ""}
+            </label>
+            <ImportFieldButton
+              onClick={() => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.width = book.remoteBook!.width;
+                });
+              }}
+              isDisabled={
+                rowData.remoteBook?.width == rowData.width ||
+                !rowData.remoteBook?.width
+              }
+              isVisible={rowData.remoteBook?.width != null}
+              className="mt-1 ml-1 addPageImportIcon"
+              style={{ height: 20, width: 20 }}
+            />
+          </div>
+        </>
+      ),
     },
     {
       field: "height",
       header: "Height",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) =>
-        NullableNumberEditor(
-          rowData.height,
-          (newValue) => {
-            setBooks((draft) => {
-              const book = findById(draft, rowData.id)!;
-              book.height = newValue;
-            });
-          },
-          "decimalNumberBookAdd",
-          false,
-          0.01
-        ),
+      customBody: (rowData: BookWithDBTag) => (
+        <>
+          <div>
+            {NullableNumberEditor(
+              rowData.height,
+              (newValue) => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.height = newValue;
+                });
+              },
+              "decimalNumberBookAdd",
+              false,
+              0.01
+            )}
+          </div>
+          <div>
+            <label style={{ fontSize: "0.7rem" }}>
+              {rowData.remoteBook && rowData.remoteBook.height != rowData.height
+                ? `(R: ${rowData.remoteBook.height})`
+                : ""}
+            </label>
+            <ImportFieldButton
+              onClick={() => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.height = book.remoteBook!.height;
+                });
+              }}
+              isDisabled={
+                rowData.remoteBook?.height == rowData.height ||
+                !rowData.remoteBook?.height
+              }
+              isVisible={rowData.remoteBook?.height != null}
+              className="mt-1 ml-1 addPageImportIcon"
+              style={{ height: 20, width: 20 }}
+            />
+          </div>
+        </>
+      ),
     },
     {
       field: "thickness",
       header: "Thickness",
       style: { width: "2%", fontSize: "small" },
-      customBody: (rowData: BookWithDBTag) =>
-        NullableNumberEditor(
-          rowData.thickness,
-          (newValue) => {
-            setBooks((draft) => {
-              const book = findById(draft, rowData.id)!;
-              book.thickness = newValue;
-            });
-          },
-          "decimalNumberBookAdd",
-          false,
-          0.01
-        ),
+      customBody: (rowData: BookWithDBTag) => (
+        <>
+          <div>
+            {NullableNumberEditor(
+              rowData.thickness,
+              (newValue) => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.thickness = newValue;
+                });
+              },
+              "decimalNumberBookAdd",
+              false,
+              0.01
+            )}
+          </div>
+          <div>
+            <label style={{ fontSize: "0.7rem" }}>
+              {rowData.remoteBook &&
+              rowData.remoteBook.thickness != rowData.thickness
+                ? `(R: ${rowData.remoteBook.thickness})`
+                : ""}
+            </label>
+            <ImportFieldButton
+              onClick={() => {
+                setBooks((draft) => {
+                  const book = findById(draft, rowData.id)!;
+                  book.thickness = book.remoteBook!.thickness;
+                });
+              }}
+              isDisabled={
+                rowData.remoteBook?.thickness == rowData.thickness ||
+                !rowData.remoteBook?.thickness
+              }
+              isVisible={rowData.remoteBook?.thickness != null}
+              className="mt-1 ml-1 addPageImportIcon"
+              style={{ height: 20, width: 20 }}
+            />
+          </div>
+        </>
+      ),
     },
     {
       field: "retailPrice",

--- a/frontend/src/pages/books/BookAdd.tsx
+++ b/frontend/src/pages/books/BookAdd.tsx
@@ -42,6 +42,7 @@ import BookDetailRelatedBooks from "./BookDetailRelatedBooks";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import ImportFieldButton from "../../components/buttons/ImportFieldButton";
+import { Tooltip } from "primereact/tooltip";
 
 export interface BookWithDBTag extends Book {
   fromDB: boolean;
@@ -97,6 +98,7 @@ export default function BookAdd() {
       header: "Cover Art",
       customBody: (rowData: BookWithDBTag) =>
         ImageTemplateWithButtons(
+          imageImportButton(rowData),
           imageDeleteButton(rowData),
           imageUploadButton(rowData),
           rowData.thumbnailURL
@@ -383,17 +385,46 @@ export default function BookAdd() {
     });
   };
 
-  // Image template buttons
+  const onImageImport = (book: BookWithDBTag) => {
+    const remoteImageURL = book.remoteBook!.thumbnailURL!;
+    axios
+      .get(remoteImageURL, {
+        responseType: "blob",
+      })
+      .then((r) => {
+        const blob = new Blob([r.data]);
+        const file = new File([blob], "imageFile" + book.id);
+        const newImageData: NewImageUploadData = {
+          imageFile: file,
+          isImageUpload: true,
+          isImageDelete: false,
+        };
 
+        setBooks((draft) => {
+          const newBook = findById(draft, book.id)!;
+          newBook.newImageData = newImageData;
+          newBook.thumbnailURL = URL.createObjectURL(file);
+        });
+      })
+      .catch(() => {
+        showFailure(toast, "Could not import image");
+      });
+  };
+
+  // Image template buttons
   const imageUploadButton = (rowData: BookWithDBTag) => {
     return (
-      <ImageUploader
-        uploadHandler={(e: FileUploadHandlerEvent) =>
-          onImageChange(e, rowData.id)
-        }
-        className=""
-        style={{ height: 10, width: 10, paddingLeft: 5 }}
-      />
+      <>
+        <Tooltip target=".custom-bookadd-tooltip" showDelay={100} />
+        <ImageUploader
+          uploadHandler={(e: FileUploadHandlerEvent) =>
+            onImageChange(e, rowData.id)
+          }
+          className="addPageImportIcon"
+          style={{ height: 20, width: 20, paddingLeft: 3, paddingRight: 3 }}
+          data-pr-tooltip={"Upload Custom Image"}
+        />
+      </>
     );
   };
 
@@ -403,8 +434,27 @@ export default function BookAdd() {
         type="button"
         icon="pi pi-trash"
         onClick={() => onImageDelete(rowData.id)}
-        className=""
-        style={{ height: 10, width: 22 }}
+        className="addPageImportIcon"
+        style={{ height: 20, width: 20 }}
+        tooltip="Delete Image"
+        tooltipOptions={{ showDelay: 100 }}
+      />
+    );
+  };
+
+  const imageImportButton = (rowData: BookWithDBTag) => {
+    return (
+      <ImportFieldButton
+        onClick={() => onImageImport(rowData)}
+        isDisabled={
+          rowData.remoteBook?.thumbnailURL == rowData.thumbnailURL ||
+          !rowData.remoteBook?.thumbnailURL
+        }
+        isVisible={rowData.remoteBook?.thumbnailURL != null}
+        className="addPageImportIcon"
+        style={{ height: 20, width: 20 }}
+        tooltip="Import Remote Image"
+        tooltipOptions={{ showDelay: 100 }}
       />
     );
   };
@@ -526,6 +576,7 @@ export default function BookAdd() {
     },
     style: { width: "2%", fontSize: 12 },
     buttonStyle: { width: 30, height: 30 },
+    hideHeader: true,
   });
 
   const columns = createColumns(COLUMNS);

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -37,6 +37,7 @@ import "../../css/MiscellaneousCSS.css";
 import { calculateDaysOfSupply, updateShelfSpace } from "../../util/NumberOps";
 import { scrollToTop } from "../../util/WindowViewportOps";
 import ImportFieldButton from "../../components/buttons/ImportFieldButton";
+import axios from "axios";
 
 interface ErrorDisplay {
   message: string;
@@ -83,6 +84,7 @@ export default function BookDetail() {
   const [imageFile, setImageFile] = useState<File>(new File([""], "filename"));
   const [isImageUploaded, setIsImageUploaded] = useState<boolean>(false);
   const [isImageRemoved, setIsImageRemoved] = useState<boolean>(false);
+  const [isImageImported, setIsImageImported] = useState(false);
   const [inventoryAdjustment, setInventoryAdjustment] = useState<number>(0);
   const [remoteBook, setRemoteBook] = useState<RemoteBook>();
 
@@ -338,6 +340,26 @@ export default function BookDetail() {
     event.options.clear();
   };
 
+  // For the import Button
+  const onImageImport = () => {
+    const newURL = remoteBook!.thumbnailURL!;
+    axios
+      .get(newURL, {
+        responseType: "blob",
+      })
+      .then((r) => {
+        const blob = new Blob([r.data]);
+        const file = new File([blob], "imageFile" + id);
+        setImage({ imageSrc: URL.createObjectURL(file), imageHash: "" });
+        setImageFile(file);
+        setIsImageUploaded(true);
+        setIsImageRemoved(false);
+      })
+      .catch(() => {
+        showFailure(toast, "Could not import image");
+      });
+  };
+
   const deleteBookPopup = () => {
     logger.debug("Delete Book Clicked");
     setDeletePopupVisible(true);
@@ -467,8 +489,21 @@ export default function BookDetail() {
     />
   );
 
+  const remoteImageButton = (
+    <Button
+      type="button"
+      label="Import Remote"
+      icon="pi pi-file-import"
+      onClick={onImageImport}
+      className={"p-button-sm my-auto ml-2"}
+      visible={isModifiable && remoteBook?.thumbnailURL != null}
+      disabled={isImageImported}
+    />
+  );
+
   const imageUploaderButtons = (
     <div className="flex justify-content-center">
+      {remoteImageButton}
       {isModifiable && imageUploadButton}
       {imageCancelButton}
       {imageDeleteButton}
@@ -529,6 +564,31 @@ export default function BookDetail() {
     <ImportFieldButton
       onClick={() => setPageCount(remoteBook?.pageCount)}
       isVisible={remoteBook?.pageCount != null && isModifiable}
+      isDisabled={remoteBook?.pageCount == pageCount || !remoteBook?.pageCount}
+    />
+  );
+
+  const importWidthButton = (
+    <ImportFieldButton
+      onClick={() => setWidth(remoteBook?.width)}
+      isVisible={remoteBook?.width != null && isModifiable}
+      isDisabled={remoteBook?.width == width || !remoteBook?.width}
+    />
+  );
+
+  const importHeightButton = (
+    <ImportFieldButton
+      onClick={() => setHeight(remoteBook?.height)}
+      isVisible={remoteBook?.height != null && isModifiable}
+      isDisabled={remoteBook?.height == height || !remoteBook?.height}
+    />
+  );
+
+  const importThicknessButton = (
+    <ImportFieldButton
+      onClick={() => setThickness(remoteBook?.thickness)}
+      isVisible={remoteBook?.thickness != null && isModifiable}
+      isDisabled={remoteBook?.thickness == thickness || !remoteBook?.thickness}
     />
   );
 
@@ -575,10 +635,10 @@ export default function BookDetail() {
           <div className="flex col-12 justify-content-start p-1">
             <div className="flex p-0">
               <TextLabel label="Title:" />
-              <p className="p-component p-text-secondary text-900 text-3xl text-center my-0">
+              <p className="p-component p-text-secondary text-900 text-m text-center my-0">
                 {title}
                 {remoteBook && remoteBook.title != title
-                  ? `\xa0 (${remoteBook.title})`
+                  ? `\xa0 (Remote: ${remoteBook.title})`
                   : ""}
               </p>
             </div>
@@ -586,10 +646,10 @@ export default function BookDetail() {
           <div className="flex col-12 justify-content-start p-1">
             <div className="flex p-0">
               <TextLabel label="Author(s):" />
-              <p className="p-component p-text-secondary text-900 text-2xl text-center m-0">
+              <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {authors}
                 {remoteBook && remoteBook.authors != authors
-                  ? `\xa0 (${remoteBook.authors})`
+                  ? `\xa0 (Remote: ${remoteBook.authors})`
                   : ""}
               </p>
             </div>
@@ -597,19 +657,19 @@ export default function BookDetail() {
           <div className="flex col-12 justify-content-start p-1">
             <div className="flex p-0 col-6">
               <TextLabel label="ISBN 13:" />
-              <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
+              <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {isbn13}
                 {remoteBook && remoteBook.isbn13 != isbn13
-                  ? `\xa0 (${remoteBook.isbn13})`
+                  ? `\xa0 (Remote: ${remoteBook.isbn13})`
                   : ""}
               </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="ISBN 10:" />
-              <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
+              <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {isbn10}
                 {remoteBook && remoteBook.isbn10 != isbn10
-                  ? `\xa0 (${remoteBook.isbn10})`
+                  ? `\xa0 (Remote: ${remoteBook.isbn10})`
                   : ""}
               </p>
             </div>
@@ -617,19 +677,19 @@ export default function BookDetail() {
           <div className="flex col-12 justify-content-start p-1">
             <div className="flex p-0 col-6">
               <TextLabel label="Publisher:" />
-              <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
+              <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {publisher}
                 {remoteBook && remoteBook.publisher != publisher
-                  ? `\xa0 (${remoteBook.publisher})`
+                  ? `\xa0 (Remote: ${remoteBook.publisher})`
                   : ""}
               </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="Publication Year:" />
-              <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
+              <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {pubYear}
                 {remoteBook && remoteBook.publishedYear != pubYear
-                  ? `\xa0 (${remoteBook.publishedYear})`
+                  ? `\xa0 (Remote: ${remoteBook.publishedYear})`
                   : ""}
               </p>
             </div>
@@ -658,9 +718,9 @@ export default function BookDetail() {
                 }
                 defaultValue={undefined}
               />
-              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
                 {remoteBook?.pageCount && remoteBook?.pageCount != pageCount
-                  ? `\xa0 (${remoteBook.pageCount})`
+                  ? `\xa0 (Remote: ${remoteBook.pageCount})`
                   : ""}
               </p>
               <p className=" vertical-align-middle">{importPageCountButton}</p>
@@ -743,7 +803,7 @@ export default function BookDetail() {
                 PriceEditor(
                   price,
                   (newValue: number) => setPrice(newValue ?? 0),
-                  "w-4",
+                  "w-4 editorBookDetail",
                   !isModifiable
                 )
               )}
@@ -778,11 +838,12 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
-              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
                 {remoteBook?.height && remoteBook?.height != height
-                  ? `\xa0 (${remoteBook.height})`
+                  ? `\xa0 (Remote: ${remoteBook.height})`
                   : ""}
               </p>
+              <p className=" vertical-align-middle">{importHeightButton}</p>
             </div>
             <div className="flex p-0 col-4">
               <TextLabel label="Width:" />
@@ -795,11 +856,12 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
-              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
                 {remoteBook?.width && remoteBook?.width != width
-                  ? `\xa0 (${remoteBook.width})`
+                  ? `\xa0 (Remote: ${remoteBook.width})`
                   : ""}
               </p>
+              <p className=" vertical-align-middle">{importWidthButton}</p>
             </div>
             <div className="flex p-0 col-4">
               <TextLabel label="Thickness:" />
@@ -814,11 +876,12 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
-              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
                 {remoteBook?.thickness && remoteBook?.thickness != thickness
-                  ? `\xa0 (${remoteBook.thickness})`
+                  ? `\xa0 (Remote: ${remoteBook.thickness})`
                   : ""}
               </p>
+              <p className=" vertical-align-middle">{importThicknessButton}</p>
             </div>
           </div>
         </form>

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -36,6 +36,7 @@ import {
 import "../../css/MiscellaneousCSS.css";
 import { calculateDaysOfSupply, updateShelfSpace } from "../../util/NumberOps";
 import { scrollToTop } from "../../util/WindowViewportOps";
+import ImportFieldButton from "../../components/buttons/ImportFieldButton";
 
 interface ErrorDisplay {
   message: string;
@@ -524,6 +525,13 @@ export default function BookDetail() {
     </Restricted>
   );
 
+  const importPageCountButton = (
+    <ImportFieldButton
+      onClick={() => setPageCount(remoteBook?.pageCount)}
+      isVisible={remoteBook?.pageCount != null && isModifiable}
+    />
+  );
+
   return (
     <div className="grid flex justify-content-center">
       <Toast ref={toast} />
@@ -655,6 +663,7 @@ export default function BookDetail() {
                   ? `\xa0 (${remoteBook.pageCount})`
                   : ""}
               </p>
+              <p className=" vertical-align-middle">{importPageCountButton}</p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="Shelf Space (in):" />

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -317,6 +317,7 @@ export default function BookDetail() {
     setImageFile(new File([""], "filename"));
     setIsImageUploaded(false);
     setIsImageRemoved(true);
+    setIsImageImported(false);
   };
 
   // For the cancel button (revert to original)
@@ -328,6 +329,7 @@ export default function BookDetail() {
     setImageFile(new File([""], "filename"));
     setIsImageUploaded(false);
     setIsImageRemoved(false);
+    setIsImageImported(false);
   };
 
   // For the upload button
@@ -337,6 +339,7 @@ export default function BookDetail() {
     setImageFile(file);
     setIsImageUploaded(true);
     setIsImageRemoved(false);
+    setIsImageImported(false);
     event.options.clear();
   };
 
@@ -354,6 +357,7 @@ export default function BookDetail() {
         setImageFile(file);
         setIsImageUploaded(true);
         setIsImageRemoved(false);
+        setIsImageImported(true);
       })
       .catch(() => {
         showFailure(toast, "Could not import image");

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import ConfirmPopup from "../../components/popups/ConfirmPopup";
 import { useNavigate, useParams } from "react-router-dom";
-import { Book, emptyBook } from "./BookList";
+import { Book, emptyBook, RemoteBook } from "./BookList";
 import { APIBook, BOOKS_API } from "../../apis/books/BooksAPI";
 import { FormikErrors, useFormik } from "formik";
 import { Toast } from "primereact/toast";
@@ -83,6 +83,7 @@ export default function BookDetail() {
   const [isImageUploaded, setIsImageUploaded] = useState<boolean>(false);
   const [isImageRemoved, setIsImageRemoved] = useState<boolean>(false);
   const [inventoryAdjustment, setInventoryAdjustment] = useState<number>(0);
+  const [remoteBook, setRemoteBook] = useState<RemoteBook>();
 
   const [isConfirmationPopupVisible, setIsConfirmationPopupVisible] =
     useState<boolean>(false);
@@ -131,6 +132,7 @@ export default function BookDetail() {
         });
         setNumOfRelatedBooks(book.numRelatedBooks);
         setRelatedBooks(book.relatedBooks!);
+        setRemoteBook(book.remoteBook);
       })
       .catch(() => showFailure(toast, "Could not fetch book data"));
     scrollToTop();
@@ -567,6 +569,9 @@ export default function BookDetail() {
               <TextLabel label="Title:" />
               <p className="p-component p-text-secondary text-900 text-3xl text-center my-0">
                 {title}
+                {remoteBook && remoteBook.title != title
+                  ? `\xa0 (${remoteBook.title})`
+                  : ""}
               </p>
             </div>
           </div>
@@ -575,6 +580,9 @@ export default function BookDetail() {
               <TextLabel label="Author(s):" />
               <p className="p-component p-text-secondary text-900 text-2xl text-center m-0">
                 {authors}
+                {remoteBook && remoteBook.authors != authors
+                  ? `\xa0 (${remoteBook.authors})`
+                  : ""}
               </p>
             </div>
           </div>
@@ -583,12 +591,18 @@ export default function BookDetail() {
               <TextLabel label="ISBN 13:" />
               <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
                 {isbn13}
+                {remoteBook && remoteBook.isbn13 != isbn13
+                  ? `\xa0 (${remoteBook.isbn13})`
+                  : ""}
               </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="ISBN 10:" />
               <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
                 {isbn10}
+                {remoteBook && remoteBook.isbn10 != isbn10
+                  ? `\xa0 (${remoteBook.isbn10})`
+                  : ""}
               </p>
             </div>
           </div>
@@ -597,12 +611,18 @@ export default function BookDetail() {
               <TextLabel label="Publisher:" />
               <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
                 {publisher}
+                {remoteBook && remoteBook.publisher != publisher
+                  ? `\xa0 (${remoteBook.publisher})`
+                  : ""}
               </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="Publication Year:" />
               <p className="p-component p-text-secondary text-900 text-xl text-center m-0">
                 {pubYear}
+                {remoteBook && remoteBook.publishedYear != pubYear
+                  ? `\xa0 (${remoteBook.publishedYear})`
+                  : ""}
               </p>
             </div>
           </div>
@@ -630,6 +650,11 @@ export default function BookDetail() {
                 }
                 defaultValue={undefined}
               />
+              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+                {remoteBook?.pageCount && remoteBook?.pageCount != pageCount
+                  ? `\xa0 (${remoteBook.pageCount})`
+                  : ""}
+              </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="Shelf Space (in):" />
@@ -715,6 +740,20 @@ export default function BookDetail() {
               )}
             </div>
           </div>
+          <div className="flex col-12 justify-content-start p-1">
+            <div className="flex col-6 p-0">
+              <TextLabel label="Remote Inventory Count: " />
+              <p className="p-component p-text-secondary text-900 text-xl text-center my-0">
+                {remoteBook?.stock ?? "-"}
+              </p>
+            </div>
+            <div className="flex col-6 p-0">
+              <TextLabel label="Remote Retail Price ($): " />
+              <p className="p-component p-text-secondary text-900 text-xl text-center my-0">
+                {remoteBook?.retailPrice ?? "-"}
+              </p>
+            </div>
+          </div>
           <h1 className="col-9 p-component p-text-secondary mb-1 mt-2 p-0 text-xl text-center text-900 color: var(--surface-800);">
             Dimensions (in)
           </h1>
@@ -730,6 +769,11 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
+              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+                {remoteBook?.height && remoteBook?.height != height
+                  ? `\xa0 (${remoteBook.height})`
+                  : ""}
+              </p>
             </div>
             <div className="flex p-0 col-4">
               <TextLabel label="Width:" />
@@ -742,6 +786,11 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
+              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+                {remoteBook?.width && remoteBook?.width != width
+                  ? `\xa0 (${remoteBook.width})`
+                  : ""}
+              </p>
             </div>
             <div className="flex p-0 col-4">
               <TextLabel label="Thickness:" />
@@ -756,6 +805,11 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
+              <p className="flex p-component p-text-secondary text-900 text-xl text-center mx-0 my-auto">
+                {remoteBook?.thickness && remoteBook?.thickness != thickness
+                  ? `\xa0 (${remoteBook.thickness})`
+                  : ""}
+              </p>
             </div>
           </div>
         </form>

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -642,9 +642,9 @@ export default function BookDetail() {
               <TextLabel label="Title:" />
               <p className="p-component p-text-secondary text-900 text-m text-center my-0">
                 {title}
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook && remoteBook.title != title
-                    ? `\xa0 (Remote: ${remoteBook.title})`
+                    ? `(Remote: ${remoteBook.title})`
                     : ""}
                 </label>
               </p>
@@ -655,9 +655,9 @@ export default function BookDetail() {
               <TextLabel label="Author(s):" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {authors}
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook && remoteBook.authors != authors
-                    ? `\xa0 (Remote: ${remoteBook.authors})`
+                    ? `(Remote: ${remoteBook.authors})`
                     : ""}
                 </label>
               </p>
@@ -668,9 +668,9 @@ export default function BookDetail() {
               <TextLabel label="ISBN 13:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {isbn13}
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook && remoteBook.isbn13 != isbn13
-                    ? `\xa0 (Remote: ${remoteBook.isbn13})`
+                    ? `(Remote: ${remoteBook.isbn13})`
                     : ""}
                 </label>
               </p>
@@ -679,9 +679,9 @@ export default function BookDetail() {
               <TextLabel label="ISBN 10:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {isbn10}
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook && remoteBook.isbn10 != isbn10
-                    ? `\xa0 (Remote: ${remoteBook.isbn10})`
+                    ? `(Remote: ${remoteBook.isbn10})`
                     : ""}
                 </label>
               </p>
@@ -692,9 +692,9 @@ export default function BookDetail() {
               <TextLabel label="Publisher:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {publisher}
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook && remoteBook.publisher != publisher
-                    ? `\xa0 (Remote: ${remoteBook.publisher})`
+                    ? `(Remote: ${remoteBook.publisher})`
                     : ""}
                 </label>
               </p>
@@ -703,9 +703,9 @@ export default function BookDetail() {
               <TextLabel label="Publication Year:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {pubYear}
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook && remoteBook.publishedYear != pubYear
-                    ? `\xa0 (Remote: ${remoteBook.publishedYear})`
+                    ? `(Remote: ${remoteBook.publishedYear})`
                     : ""}
                 </label>
               </p>
@@ -737,9 +737,9 @@ export default function BookDetail() {
               />
               <p className=" vertical-align-middle">{importPageCountButton}</p>
               <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
-                <label className="text-blue-800">
+                <label className="text-blue-800 pl-1">
                   {remoteBook?.pageCount && remoteBook?.pageCount != pageCount
-                    ? `\xa0 (Remote: ${remoteBook.pageCount})`
+                    ? `(Remote: ${remoteBook.pageCount})`
                     : ""}
                 </label>
               </p>
@@ -858,9 +858,9 @@ export default function BookDetail() {
                 min={0.01}
               />
               <p className=" vertical-align-middle">{importHeightButton}</p>
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800 pl-1">
                 {remoteBook?.height && remoteBook?.height != height
-                  ? `\xa0 (Remote: ${remoteBook.height})`
+                  ? `(Remote: ${remoteBook.height})`
                   : ""}
               </p>
             </div>
@@ -876,9 +876,9 @@ export default function BookDetail() {
                 min={0.01}
               />
               <p className=" vertical-align-middle">{importWidthButton}</p>
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800 pl-1">
                 {remoteBook?.width && remoteBook?.width != width
-                  ? `\xa0 (Remote: ${remoteBook.width})`
+                  ? `(Remote: ${remoteBook.width})`
                   : ""}
               </p>
             </div>
@@ -896,9 +896,9 @@ export default function BookDetail() {
                 min={0.01}
               />
               <p className=" vertical-align-middle">{importThicknessButton}</p>
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800">
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800 pl-1">
                 {remoteBook?.thickness && remoteBook?.thickness != thickness
-                  ? `\xa0 (Remote: ${remoteBook.thickness})`
+                  ? `(Remote: ${remoteBook.thickness})`
                   : ""}
               </p>
             </div>

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -637,9 +637,11 @@ export default function BookDetail() {
               <TextLabel label="Title:" />
               <p className="p-component p-text-secondary text-900 text-m text-center my-0">
                 {title}
-                {remoteBook && remoteBook.title != title
-                  ? `\xa0 (Remote: ${remoteBook.title})`
-                  : ""}
+                <label className="text-blue-800">
+                  {remoteBook && remoteBook.title != title
+                    ? `\xa0 (Remote: ${remoteBook.title})`
+                    : ""}
+                </label>
               </p>
             </div>
           </div>
@@ -648,9 +650,11 @@ export default function BookDetail() {
               <TextLabel label="Author(s):" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {authors}
-                {remoteBook && remoteBook.authors != authors
-                  ? `\xa0 (Remote: ${remoteBook.authors})`
-                  : ""}
+                <label className="text-blue-800">
+                  {remoteBook && remoteBook.authors != authors
+                    ? `\xa0 (Remote: ${remoteBook.authors})`
+                    : ""}
+                </label>
               </p>
             </div>
           </div>
@@ -659,18 +663,22 @@ export default function BookDetail() {
               <TextLabel label="ISBN 13:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {isbn13}
-                {remoteBook && remoteBook.isbn13 != isbn13
-                  ? `\xa0 (Remote: ${remoteBook.isbn13})`
-                  : ""}
+                <label className="text-blue-800">
+                  {remoteBook && remoteBook.isbn13 != isbn13
+                    ? `\xa0 (Remote: ${remoteBook.isbn13})`
+                    : ""}
+                </label>
               </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="ISBN 10:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {isbn10}
-                {remoteBook && remoteBook.isbn10 != isbn10
-                  ? `\xa0 (Remote: ${remoteBook.isbn10})`
-                  : ""}
+                <label className="text-blue-800">
+                  {remoteBook && remoteBook.isbn10 != isbn10
+                    ? `\xa0 (Remote: ${remoteBook.isbn10})`
+                    : ""}
+                </label>
               </p>
             </div>
           </div>
@@ -679,18 +687,22 @@ export default function BookDetail() {
               <TextLabel label="Publisher:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {publisher}
-                {remoteBook && remoteBook.publisher != publisher
-                  ? `\xa0 (Remote: ${remoteBook.publisher})`
-                  : ""}
+                <label className="text-blue-800">
+                  {remoteBook && remoteBook.publisher != publisher
+                    ? `\xa0 (Remote: ${remoteBook.publisher})`
+                    : ""}
+                </label>
               </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="Publication Year:" />
               <p className="p-component p-text-secondary text-900 text-m text-center m-0">
                 {pubYear}
-                {remoteBook && remoteBook.publishedYear != pubYear
-                  ? `\xa0 (Remote: ${remoteBook.publishedYear})`
-                  : ""}
+                <label className="text-blue-800">
+                  {remoteBook && remoteBook.publishedYear != pubYear
+                    ? `\xa0 (Remote: ${remoteBook.publishedYear})`
+                    : ""}
+                </label>
               </p>
             </div>
           </div>
@@ -718,12 +730,14 @@ export default function BookDetail() {
                 }
                 defaultValue={undefined}
               />
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
-                {remoteBook?.pageCount && remoteBook?.pageCount != pageCount
-                  ? `\xa0 (Remote: ${remoteBook.pageCount})`
-                  : ""}
-              </p>
               <p className=" vertical-align-middle">{importPageCountButton}</p>
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
+                <label className="text-blue-800">
+                  {remoteBook?.pageCount && remoteBook?.pageCount != pageCount
+                    ? `\xa0 (Remote: ${remoteBook.pageCount})`
+                    : ""}
+                </label>
+              </p>
             </div>
             <div className="flex p-0 col-6">
               <TextLabel label="Shelf Space (in):" />
@@ -838,12 +852,12 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
+              <p className=" vertical-align-middle">{importHeightButton}</p>
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800">
                 {remoteBook?.height && remoteBook?.height != height
                   ? `\xa0 (Remote: ${remoteBook.height})`
                   : ""}
               </p>
-              <p className=" vertical-align-middle">{importHeightButton}</p>
             </div>
             <div className="flex p-0 col-4">
               <TextLabel label="Width:" />
@@ -856,12 +870,12 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
+              <p className=" vertical-align-middle">{importWidthButton}</p>
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800">
                 {remoteBook?.width && remoteBook?.width != width
                   ? `\xa0 (Remote: ${remoteBook.width})`
                   : ""}
               </p>
-              <p className=" vertical-align-middle">{importWidthButton}</p>
             </div>
             <div className="flex p-0 col-4">
               <TextLabel label="Thickness:" />
@@ -876,12 +890,12 @@ export default function BookDetail() {
                 valueClassName="flex 2rem"
                 min={0.01}
               />
-              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto">
+              <p className=" vertical-align-middle">{importThicknessButton}</p>
+              <p className="flex p-component p-text-secondary text-900 text-m text-center mx-0 my-auto text-blue-800">
                 {remoteBook?.thickness && remoteBook?.thickness != thickness
                   ? `\xa0 (Remote: ${remoteBook.thickness})`
                   : ""}
               </p>
-              <p className=" vertical-align-middle">{importThicknessButton}</p>
             </div>
           </div>
         </form>

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -464,7 +464,7 @@ export default function BookDetail() {
     <ImageUploader
       disabled={!isModifiable}
       uploadHandler={onImageUpload}
-      className="p-button-sm my-auto"
+      className="p-button-sm my-auto ml-2"
     />
   );
 
@@ -492,7 +492,7 @@ export default function BookDetail() {
   const remoteImageButton = (
     <Button
       type="button"
-      label="Import Remote"
+      label="Remote"
       icon="pi pi-file-import"
       onClick={onImageImport}
       className={"p-button-sm my-auto ml-2"}

--- a/frontend/src/pages/books/BookDetail.tsx
+++ b/frontend/src/pages/books/BookDetail.tsx
@@ -358,6 +358,7 @@ export default function BookDetail() {
         setIsImageUploaded(true);
         setIsImageRemoved(false);
         setIsImageImported(true);
+        showSuccess(toast, "Image imported successfully");
       })
       .catch(() => {
         showFailure(toast, "Could not import image");

--- a/frontend/src/pages/books/BookList.tsx
+++ b/frontend/src/pages/books/BookList.tsx
@@ -63,6 +63,23 @@ export interface Book {
   isGhost?: boolean;
   numRelatedBooks?: number;
   relatedBooks?: RelatedBook[];
+  remoteBook?: RemoteBook;
+}
+
+export interface RemoteBook {
+  title: string;
+  authors: string;
+  isbn13: string;
+  isbn10: string;
+  publisher: string;
+  publishedYear: number;
+  pageCount?: number;
+  width?: number;
+  height?: number;
+  thickness?: number;
+  retailPrice: number;
+  stock: number;
+  thumbnailURL?: string;
 }
 
 interface Filters {
@@ -117,6 +134,8 @@ export const columnsMeta: ColumnMeta[] = [
   { field: "numRelatedBooks", header: "# of Related Books" },
   { field: "lastMonthSales", header: "Last Month Sales" },
   { field: "shelfSpace", header: "Shelf Space" },
+  { field: "remoteInventoryCount", header: "Remote Inventory Count" },
+  { field: "remoteRetailPrice", header: "Remote Retail Price" },
 ];
 
 export default function BookList() {
@@ -308,6 +327,26 @@ export default function BookList() {
       style: { minWidth: "3rem" },
       hidden: !(
         visibleColumns.filter((item) => item.field == "shelfSpace").length > 0
+      ),
+    },
+    {
+      field: "remoteInventoryCount",
+      header: "Remote Inventory Count",
+      customBody: (rowData: Book) => rowData.remoteBook?.stock ?? "-",
+      style: { minWidth: "3rem" },
+      hidden: !(
+        visibleColumns.filter((item) => item.field == "remoteInventoryCount")
+          .length > 0
+      ),
+    },
+    {
+      field: "remoteRetailPrice",
+      header: "Remote Retail Price ($)",
+      customBody: (rowData: Book) => rowData.remoteBook?.retailPrice ?? "-",
+      style: { minWidth: "3rem" },
+      hidden: !(
+        visibleColumns.filter((item) => item.field == "remoteRetailPrice")
+          .length > 0
       ),
     },
   ];

--- a/frontend/src/pages/books/BookList.tsx
+++ b/frontend/src/pages/books/BookList.tsx
@@ -154,7 +154,7 @@ export default function BookList() {
   const [genreNamesList, setGenreNamesList] = useState<string[]>([]); // List of all genre names
 
   const [visibleColumns, setVisibleColumns] = useState<ColumnMeta[]>(
-    [0, 1, 2, 3, 7, 8, 9, 10, 11, 12].map((x) => columnsMeta[x])
+    [0, 1, 2, 3, 7, 8, 9, 10, 11, 12, 14, 15].map((x) => columnsMeta[x])
   );
 
   const [toggleColumnPopupVisible, setToggleColumnPopupVisible] =

--- a/frontend/src/pages/casedesigner/detail/DnDComponents.tsx
+++ b/frontend/src/pages/casedesigner/detail/DnDComponents.tsx
@@ -81,7 +81,7 @@ export function DraggableBook(props: DraggableBookProps) {
     <SortableItem id={props.book.id} key={props.book.id}>
       <div className="pl-1">
         <div className="flex col-12 justify-content-start p-1">
-          <Tooltip target=".custom-displaybook-tooltip" showDelay={700} />
+          <Tooltip target=".custom-displaybook-tooltip" showDelay={400} />
           <Image
             src={props.book.bookImageURL}
             id={props.book.id}


### PR DESCRIPTION
## Feature Description/Implementation
- New fields on book list
- View differing intrinsic fields on book detail view
- Allow user to import editable intrinsic fields on book modify page (page count, dimensions, cover art)
- Allow user to import editable intrinsic fields on book add page

## Dependencies

## Everything Else
- Will have to change implementation because of refactor
- I can't think of a clean way to disable the import image button if our image is the same as the subsidiary. This is because the URLs will always be different. I suppose I could compare the bytes of the image, but this seems excessive.
- Our subsidiary has lower resolution images, so we may need to change something to make it look nicer on our book detail page
