### PR TITLE
[BackEnd] Created New Remote Subsidiary Book Lookup Endpoint

### DIFF
--- a/backend/books/remote_books.py
+++ b/backend/books/remote_books.py
@@ -12,7 +12,9 @@ class RemoteSubsidiaryTools:
         url = self._remote_store_api_url
         headers = self.create_headers()
         payload = self.create_payload(isbn)
-        response = requests.request("POST", url, headers=headers, data=payload)
+        # It’s a good practice to set connect timeouts to slightly larger than a multiple of 3, which is the default TCP packet retransmission window.
+        # https://www.hjp.at/doc/rfc/rfc2988.txt
+        response = requests.request("POST", url, headers=headers, data=payload, timeout=(3.05, 9.05))
 
         ret = response.json()
 

--- a/backend/books/serializers.py
+++ b/backend/books/serializers.py
@@ -121,12 +121,11 @@ class BookSerializer(serializers.ModelSerializer):
     num_related_books = serializers.SerializerMethodField()
     related_books = serializers.SerializerMethodField()
     related_book_group = serializers.PrimaryKeyRelatedField(queryset=RelatedBookGroup.objects.all(), write_only=True, allow_null=True)
-    remote_book = serializers.SerializerMethodField()
 
     class Meta:
         model = Book
         fields = '__all__'
-        read_only_fields = ['title', 'authors', 'isbn_13', 'isbn_10', 'publisher', 'publishedDate', 'image_url', 'best_buyback_price', 'last_month_sales', 'num_related_books', 'related_books', 'remote_book']
+        read_only_fields = ['title', 'authors', 'isbn_13', 'isbn_10', 'publisher', 'publishedDate', 'image_url', 'best_buyback_price', 'last_month_sales', 'num_related_books', 'related_books']
 
     def to_representation(self, instance):
         result = super(BookSerializer, self).to_representation(instance)
@@ -230,12 +229,6 @@ class BookSerializer(serializers.ModelSerializer):
 
         def case_sales_reconciliation(self):
             return -self.default
-    
-    def get_remote_book(self, instance):
-        remote_api_caller = RemoteSubsidiaryTools()
-        isbn_13 = instance.isbn_13
-        response = remote_api_caller.get_remote_book_data(isbn_13)
-        return response
 
 
 class AuthorSerializer(serializers.ModelSerializer):

--- a/backend/books/urls.py
+++ b/backend/books/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import ISBNSearchView, ListCreateBookAPIView, RetrieveUpdateDestroyBookAPIView, RetrieveExternalBookImageAPIView, CSVExportBookAPIView, CreateBookInventoryCorrectionAPIView, RemoteBookSearchView
+from .views import ISBNSearchView, ListCreateBookAPIView, RetrieveUpdateDestroyBookAPIView, RetrieveExternalBookImageAPIView, CSVExportBookAPIView, CreateBookInventoryCorrectionAPIView, RemoteBookSearchView, SubsidiaryRemoteBookSearchView
 
 app_name = 'books'
 
@@ -9,6 +9,7 @@ urlpatterns = [
     path('/image/<book_id>', RetrieveExternalBookImageAPIView.as_view()),
     path('/correction/<book_id>', CreateBookInventoryCorrectionAPIView.as_view()),
     path('/isbns', ISBNSearchView.as_view()),
+    path('/subsidiary/lookup', SubsidiaryRemoteBookSearchView.as_view()),
     path('/remote/lookup', RemoteBookSearchView.as_view()),
     path('/<id>', RetrieveUpdateDestroyBookAPIView.as_view()),
 ]

--- a/backend/books/views.py
+++ b/backend/books/views.py
@@ -612,7 +612,7 @@ class SubsidiaryRemoteBookSearchView(APIView):
 
         ret = []
         for isbn in parsed_isbn_list:
-            if response[isbn]:
+            if response.get(isbn, None):
                 parsed_data = self.parse_response_data(response[isbn])
                 ret.append(parsed_data)
         


### PR DESCRIPTION
## Feature Description/Implementation
Created new remote subsidiary book lookup at `/books/subsidiary/lookup`

Removed auto get of remote subsidiary from book list get and book retrive

Initial Book Lookup automatically gets remote book data as speed is not concern here (and is relatively fast). There is no need for two asynchronous requests here.

## Dependencies

## Everything Else
